### PR TITLE
Add asf.yaml to setup description of github repo

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,12 @@
+github:
+  description: "Apache Teaclave (incubating) is an open source universal secure computing platform"
+  homepage: https://teaclave.org
+  labels:
+    - universal-secure-computing
+    - trusted-execution-environment
+    - function-as-a-service
+    - secure-multiparty-computation
+    - tee
+    - sgx
+    - faas
+    - rust


### PR DESCRIPTION
## Description

Use `.asf.yaml` to setup github repo. (refer to: https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories)