### PR TITLE
Generate *_enclave.so instead of *.enclave.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,9 +119,8 @@ foreach(_i RANGE ${SGX_LIB_LAST_INDEX})
     list(GET SGX_LIBS ${_i} _pkg_name)
     list(GET SGX_LIB_PATHS ${_i} _pkg_path)
     list(GET SGX_LIB_CATEGORIES ${_i} _category)
-    sgxlib_pkgname_2_modname(${_pkg_name} _mod_name)
     add_sgx_build_target(${_pkg_path} ${_pkg_name}
-        DEPENDS prep "${SGXAPP_PREFIX}-${_mod_name}" pycomponent
+        DEPENDS prep pycomponent
         INSTALL_DIR ${MESATEE_INSTALL_DIR}/${_category}
     )
 endforeach()

--- a/cmake/UtilTargets.cmake
+++ b/cmake/UtilTargets.cmake
@@ -17,6 +17,7 @@ add_custom_target(check
 	COMMAND RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN} find ${MESATEE_PROJECT_ROOT}
         -path ${MESATEE_PROJECT_ROOT}/third_party -prune -o
         -path ${MESATEE_PROJECT_ROOT}/.git -prune -o
+        -path ${MESATEE_BUILD_ROOT} -prune -o
         -name "*.rs" -exec rustfmt --check {} +
     COMMENT "Checking the format of every .rs file"
     DEPENDS prep

--- a/cmake/scripts/sgx_link_sign.sh
+++ b/cmake/scripts/sgx_link_sign.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-REQUIRED_ENVS=("CMAKE_C_COMPILER" "CUR_MODULE_NAME" "CUR_MODULE_PATH"
+REQUIRED_ENVS=("CMAKE_C_COMPILER" "CUR_PKG_NAME" "CUR_PKG_PATH"
 "CUR_INSTALL_DIR" "MESATEE_OUT_DIR" "MESATEE_PROJECT_ROOT" "Service_Library_Name"
 "SGX_COMMON_CFLAGS" "SGX_ENCLAVE_SIGNER" "SGX_LIBRARY_PATH" "TARGET" "Trts_Library_Name"
 "TRUSTED_TARGET_DIR")
@@ -8,10 +8,11 @@ for var in "${REQUIRED_ENVS[@]}"; do
     [ -z "${!var}" ] && echo "Please set ${var}" && exit -1
 done
 
-LIBENCLAVE_PATH="${TRUSTED_TARGET_DIR}/${TARGET}/lib${CUR_MODULE_NAME}_enclave.a"
-CONFIG_PATH="${MESATEE_PROJECT_ROOT}/${CUR_MODULE_PATH}/Enclave.config.xml"
-SIGNED_PATH="${CUR_INSTALL_DIR}/${CUR_MODULE_NAME}.enclave.signed.so"
-CUR_ENCLAVE_INFO_PATH="${MESATEE_OUT_DIR}/${CUR_MODULE_NAME}_enclave_info.toml"
+LIBENCLAVE_PATH="${TRUSTED_TARGET_DIR}/${TARGET}/lib${CUR_PKG_NAME}.a"
+CONFIG_PATH="${MESATEE_PROJECT_ROOT}/${CUR_PKG_PATH}/Enclave.config.xml"
+SIGNED_PATH="${CUR_INSTALL_DIR}/${CUR_PKG_NAME}.signed.so"
+CUR_ENCLAVE_INFO_PATH="${MESATEE_OUT_DIR}/${CUR_PKG_NAME}_info.toml"
+
 if [ ! "$LIBENCLAVE_PATH" -nt "$SIGNED_PATH" ] \
     && [ ! "$CONFIG_PATH" -nt "$SIGNED_PATH" ] \
     && [  ! "$SIGNED_PATH" -nt "$CUR_ENCLAVE_INFO_PATH" ]; then
@@ -20,21 +21,21 @@ if [ ! "$LIBENCLAVE_PATH" -nt "$SIGNED_PATH" ] \
 fi
 cd ${MESATEE_OUT_DIR}
 ${CMAKE_C_COMPILER} libEnclave_t.o -o \
-    ${MESATEE_OUT_DIR}/${CUR_MODULE_NAME}.enclave.so ${SGX_COMMON_CFLAGS} \
+    ${MESATEE_OUT_DIR}/${CUR_PKG_NAME}.so ${SGX_COMMON_CFLAGS} \
     -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles \
     -L${SGX_LIBRARY_PATH} -Wl,--whole-archive -l${Trts_Library_Name} \
     -Wl,--no-whole-archive -Wl,--start-group \
     -l${Service_Library_Name} -lsgx_tprotected_fs -lsgx_tkey_exchange \
     -lsgx_tstdc -lsgx_tcxx -lsgx_tservice -lsgx_tcrypto \
     -L${MESATEE_OUT_DIR} -lpycomponent ffi.o -lpypy-c -lsgx_tlibc_ext -lffi \
-    -L${TRUSTED_TARGET_DIR}/${TARGET} -l${CUR_MODULE_NAME}_enclave -Wl,--end-group \
+    -L${TRUSTED_TARGET_DIR}/${TARGET} -l${CUR_PKG_NAME} -Wl,--end-group \
     -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--no-undefined \
     -Wl,-pie,-eenclave_entry -Wl,--export-dynamic  \
     -Wl,--defsym,__ImageBase=0 \
     -Wl,--gc-sections \
     -Wl,--version-script=${MESATEE_PROJECT_ROOT}/cmake/scripts/Enclave.lds
 ${SGX_ENCLAVE_SIGNER} sign -key ${MESATEE_PROJECT_ROOT}/keys/enclave_signing_key.pem \
-    -enclave ${CUR_MODULE_NAME}.enclave.so \
-    -out ${CUR_INSTALL_DIR}/${CUR_MODULE_NAME}.enclave.signed.so \
-    -config ${MESATEE_PROJECT_ROOT}/${CUR_MODULE_PATH}/Enclave.config.xml \
-    -dumpfile ${CUR_MODULE_NAME}.enclave.meta.txt > /dev/null 2>&1
+    -enclave ${CUR_PKG_NAME}.so \
+    -out ${CUR_INSTALL_DIR}/${CUR_PKG_NAME}.signed.so \
+    -config ${MESATEE_PROJECT_ROOT}/${CUR_PKG_PATH}/Enclave.config.xml \
+    -dumpfile ${CUR_PKG_NAME}.meta.txt > /dev/null 2>&1

--- a/docs/how_to_build.md
+++ b/docs/how_to_build.md
@@ -95,6 +95,5 @@ help set the variables. Below is the description for the environment variables:
 * ``MESATEE_BUILD_CFG_DIR``: directory containing the compile time config
 * `MESATEE_SOTRAGE_DIR`: directory for TDFS data storage, default is `/tmp`
 * ``MESATEE_AUDITORS_DIR``: directory containing auditors' public keys and endorsement to TEE enclaves (digital signatures)
-* ``MESATEE_TEST_MODE``: whether executing in testing mode
 * ``RUST_LOG``: logging levels
 * ``RUST_BACKTRACE``: whether to enable backtrace logging on crash

--- a/mesatee_core/src/lib.rs
+++ b/mesatee_core/src/lib.rs
@@ -57,15 +57,12 @@ pub mod config;
 #[cfg(feature = "mesalock_sgx")]
 pub fn init_service(name: &str) -> Result<()> {
     use std::backtrace;
+    env_logger::init();
 
     debug!("Enclave [{}]: Initializing...", name);
 
-    env_logger::init();
-    if backtrace::enable_backtrace(
-        format!("{}.enclave.signed.so", name),
-        backtrace::PrintFormat::Full,
-    )
-    .is_err()
+    if backtrace::enable_backtrace(format!("{}.signed.so", name), backtrace::PrintFormat::Full)
+        .is_err()
     {
         error!("Cannot enable backtrace");
         return Err(Error::from(ErrorKind::ECallError));

--- a/mesatee_services/acs/sgx_app/src/main.rs
+++ b/mesatee_services/acs/sgx_app/src/main.rs
@@ -31,7 +31,7 @@ use teaclave_binder::TeeBinder;
 fn main() -> Result<()> {
     env_logger::init();
 
-    let tee = match TeeBinder::new("acs", 1) {
+    let tee = match TeeBinder::new(env!("CARGO_PKG_NAME"), 1) {
         Ok(r) => {
             info!("Init TEE Successfully!");
             r

--- a/mesatee_services/fns/sgx_app/src/main.rs
+++ b/mesatee_services/fns/sgx_app/src/main.rs
@@ -31,7 +31,7 @@ use teaclave_binder::TeeBinder;
 fn main() -> Result<()> {
     env_logger::init();
 
-    let tee = match TeeBinder::new("fns", 1) {
+    let tee = match TeeBinder::new(env!("CARGO_PKG_NAME"), 1) {
         Ok(r) => {
             info!("Init TEE Successfully!");
             r

--- a/mesatee_services/tms/sgx_app/src/main.rs
+++ b/mesatee_services/tms/sgx_app/src/main.rs
@@ -34,7 +34,7 @@ use mesatee_core::prelude::*;
 fn main() -> Result<()> {
     env_logger::init();
 
-    let tee = match TeeBinder::new("tms", 1) {
+    let tee = match TeeBinder::new(env!("CARGO_PKG_NAME"), 1) {
         Ok(r) => {
             info!("Init TEE Successfully!");
             r

--- a/teaclave_binder/src/binder.rs
+++ b/teaclave_binder/src/binder.rs
@@ -28,7 +28,7 @@ use mesatee_core::ipc::protos::ECallCommand;
 use mesatee_core::ipc::IpcSender;
 use mesatee_core::Result;
 
-static ENCLAVE_FILE_SUFFIX: &str = "enclave.signed.so";
+static ENCLAVE_FILE_SUFFIX: &str = "_enclave.signed.so";
 
 use std::sync::Arc;
 #[derive(Clone)]
@@ -100,7 +100,7 @@ fn init_enclave(enclave_name: &str, debug_launch: i32) -> Result<SgxEnclave> {
         misc_select: 0,
     };
 
-    let enclave_file = format!("{}.{}", enclave_name, ENCLAVE_FILE_SUFFIX);
+    let enclave_file = format!("{}{}", enclave_name, ENCLAVE_FILE_SUFFIX);
 
     let enclave = SgxEnclave::create(
         enclave_file,

--- a/tests/functional_test/sgx_app/src/main.rs
+++ b/tests/functional_test/sgx_app/src/main.rs
@@ -58,7 +58,7 @@ fn test_from_unstrusted() {
 }
 
 fn test_in_tee() -> Result<()> {
-    let tee = match TeeBinder::new("functional_test", 1) {
+    let tee = match TeeBinder::new(env!("CARGO_PKG_NAME"), 1) {
         Ok(r) => {
             info!("Init TEE Successfully!");
             r


### PR DESCRIPTION
## Description
- Generate *_enclave.so instead of *.enclave.so for the convenience of symbol retrieving.
- Remove unused env MESATEE_TEST_MODE.
- Remove <build_dir> from target `check`.
- Fix format of mesatee_core/src/lib.rs.

## Type of change (select applied and DELETE the others)
- [x] Code cleanup or just sync with upstream third-party crates

## How Has This Been Tested?
Yes
## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
