### PR TITLE
Optimize RPC TLS config

### DIFF
--- a/mesatee_core/src/rpc/sgx/client.rs
+++ b/mesatee_core/src/rpc/sgx/client.rs
@@ -19,6 +19,8 @@ use std::sync::Arc;
 
 use crate::rpc::sgx::EnclaveAttr;
 
+#[cfg(feature = "mesalock_sgx")]
+use sgx_types::sgx_sha256_hash_t;
 #[cfg(not(feature = "mesalock_sgx"))]
 use std::sync::RwLock;
 #[cfg(feature = "mesalock_sgx")]
@@ -29,17 +31,74 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 
 lazy_static! {
-    static ref CLIENTCONFIGCACHE: RwLock<HashMap<u64, Arc<rustls::ClientConfig>>> =
-        { RwLock::new(HashMap::new()) };
+    static ref CLIENT_CONFIG_CACHE: RwLock<ClientConfigCache> =
+        { RwLock::new(ClientConfigCache::default()) };
+}
+
+#[cfg(feature = "mesalock_sgx")]
+#[derive(Default)]
+struct ClientConfigCache {
+    private_key_sha256: sgx_sha256_hash_t,
+    target_configs: HashMap<Arc<EnclaveAttr>, Arc<rustls::ClientConfig>>,
 }
 
 #[cfg(not(feature = "mesalock_sgx"))]
-pub(crate) fn get_tls_config(server_attr: EnclaveAttr) -> Arc<rustls::ClientConfig> {
+#[derive(Default)]
+struct ClientConfigCache {
+    target_configs: HashMap<Arc<EnclaveAttr>, Arc<rustls::ClientConfig>>,
+}
+
+#[cfg(feature = "mesalock_sgx")]
+pub(crate) fn get_tls_config(server_attr: Arc<EnclaveAttr>) -> Arc<rustls::ClientConfig> {
+    use crate::rpc::sgx::ra::get_ra_cert;
+
+    // To re-use existing TLS cache, we need to first check if the server has
+    // updated his RA cert
+    let cert_key = get_ra_cert();
+
+    // TODO: add wrapper function
+    if let Ok(cfg_cache) = CLIENT_CONFIG_CACHE.try_read() {
+        if let Some(cfg) = cfg_cache.target_configs.get(&server_attr) {
+            return cfg.clone();
+        }
+    }
+
+    let certs = vec![rustls::Certificate(cert_key.cert)];
+    let privkey = rustls::PrivateKey(cert_key.private_key);
+
+    let mut client_cfg = rustls::ClientConfig::new();
+    client_cfg.set_single_client_cert(certs, privkey);
+    client_cfg
+        .dangerous()
+        .set_certificate_verifier(server_attr.clone());
+    client_cfg.versions.clear();
+    client_cfg.versions.push(rustls::ProtocolVersion::TLSv1_2);
+
+    let final_arc = Arc::new(client_cfg);
+
+    // TODO: add wrapper function
+    if let Ok(mut cfg_cache) = CLIENT_CONFIG_CACHE.try_write() {
+        if cfg_cache.private_key_sha256 != cert_key.private_key_sha256 {
+            *cfg_cache = ClientConfigCache {
+                private_key_sha256: cert_key.private_key_sha256,
+                target_configs: HashMap::new(),
+            }
+        }
+
+        let _ = cfg_cache
+            .target_configs
+            .insert(server_attr, final_arc.clone());
+    }
+
+    final_arc
+}
+
+#[cfg(not(feature = "mesalock_sgx"))]
+pub(crate) fn get_tls_config(server_attr: Arc<EnclaveAttr>) -> Arc<rustls::ClientConfig> {
     // We believe a client from untrusted side do not change his tls cert
     // during single execution.
-    let cattr_hash: u64 = server_attr.calculate_hash();
-    if let Ok(cfg_cache) = CLIENTCONFIGCACHE.try_read() {
-        if let Some(cfg) = cfg_cache.get(&cattr_hash) {
+    if let Ok(cfg_cache) = CLIENT_CONFIG_CACHE.try_read() {
+        if let Some(cfg) = cfg_cache.target_configs.get(&server_attr) {
             return cfg.clone();
         }
     }
@@ -48,70 +107,16 @@ pub(crate) fn get_tls_config(server_attr: EnclaveAttr) -> Arc<rustls::ClientConf
 
     client_cfg
         .dangerous()
-        .set_certificate_verifier(Arc::new(server_attr));
+        .set_certificate_verifier(server_attr.clone());
     client_cfg.versions.clear();
     client_cfg.versions.push(rustls::ProtocolVersion::TLSv1_2);
 
     let final_arc = Arc::new(client_cfg);
 
-    if let Ok(mut cfg_cache) = CLIENTCONFIGCACHE.try_write() {
-        let _ = cfg_cache.insert(cattr_hash, final_arc.clone());
-    }
-
-    final_arc
-}
-
-#[cfg(feature = "mesalock_sgx")]
-pub(crate) fn get_tls_config(server_attr: EnclaveAttr) -> Arc<rustls::ClientConfig> {
-    use super::calc_hash;
-    use crate::rpc::sgx::ra::get_ra_cert;
-
-    // To re-use existing TLS cache, we need to first check if the server has
-    // updated his RA cert
-    let (cert_key, invalidate_cache) = get_ra_cert();
-
-    // calc_hash generates a u64 for (EnclaveAttr, CertKeyPair)
-    // According to the below code, as long as cert_key is unchanged,
-    // the `client_cfg` would not change, because it only take two
-    // parameters: EnclaveAttr, and CertKeyPair
-    let stat_hash: u64 = calc_hash(&server_attr, &cert_key);
-
-    if !invalidate_cache {
-        if let Ok(cfg_cache) = CLIENTCONFIGCACHE.try_read() {
-            if let Some(cfg) = cfg_cache.get(&stat_hash) {
-                return cfg.clone();
-            }
-        }
-    } else {
-        match CLIENTCONFIGCACHE.write() {
-            Ok(mut cfg_cache) => {
-                info!("CLIENTCONFIGCACHE invalidate all config cache!");
-                cfg_cache.clear();
-            }
-            Err(_) => {
-                // Poisoned
-                // I don't think we should panic here.
-                error!("CLIENTCONFIGCACHE invalidate cache failed!");
-            }
-        }
-    }
-
-    let mut certs = std::vec::Vec::new();
-    certs.push(rustls::Certificate(cert_key.cert));
-    let privkey = rustls::PrivateKey(cert_key.private_key);
-
-    let mut client_cfg = rustls::ClientConfig::new();
-    client_cfg.set_single_client_cert(certs, privkey);
-    client_cfg
-        .dangerous()
-        .set_certificate_verifier(Arc::new(server_attr));
-    client_cfg.versions.clear();
-    client_cfg.versions.push(rustls::ProtocolVersion::TLSv1_2);
-
-    let final_arc = Arc::new(client_cfg);
-
-    if let Ok(mut cfg_cache) = CLIENTCONFIGCACHE.try_write() {
-        let _ = cfg_cache.insert(stat_hash, final_arc.clone());
+    if let Ok(mut cfg_cache) = CLIENT_CONFIG_CACHE.try_write() {
+        let _ = cfg_cache
+            .target_configs
+            .insert(server_attr, final_arc.clone());
     }
 
     final_arc

--- a/teaclave_config/build.config.toml
+++ b/teaclave_config/build.config.toml
@@ -1,8 +1,5 @@
 # Teaclave Build Config
 
-# Service provider's root CA certificate to verify clients
-sp_root_ca_cert = { path = "../keys/sp_root_ca_cert.pem" }
-
 # Intel Attestation Service root CA certificate to verify attestation report
 ias_root_ca_cert = { path = "../keys/ias_root_ca_cert.pem" }
 

--- a/teaclave_config/config_gen/main.rs
+++ b/teaclave_config/config_gen/main.rs
@@ -9,7 +9,6 @@ use std::path::PathBuf;
 
 #[derive(Serialize, Deserialize)]
 struct BuildConfigToml {
-    sp_root_ca_cert: ConfigSource,
     ias_root_ca_cert: ConfigSource,
     auditor_public_keys: Vec<ConfigSource>,
     rpc_max_message_size: u32,
@@ -45,7 +44,6 @@ fn main() {
     let contents = fs::read_to_string(&args[1]).expect("Something went wrong reading the file");
     let config: BuildConfigToml = toml::from_str(&contents).expect("Failed to parse the config.");
 
-    let sp_root_ca_cert = display_config_source(&config.sp_root_ca_cert);
     let ias_root_ca_cert = display_config_source(&config.ias_root_ca_cert);
 
     let mut auditor_public_keys = String::new();
@@ -61,20 +59,17 @@ fn main() {
         r#"
     #[derive(Debug)]
     pub struct BuildConfig<'a> {{
-        pub sp_root_ca_cert: &'a [u8],
         pub ias_root_ca_cert: &'a [u8],
         pub auditor_public_keys: &'a [&'a [u8];{}],
         pub rpc_max_message_size: u64,
     }}
 
     pub static BUILD_CONFIG: BuildConfig<'static> = BuildConfig {{
-        sp_root_ca_cert: {},
         ias_root_ca_cert: {},
         auditor_public_keys: {},
         rpc_max_message_size: {},
     }};"#,
         config.auditor_public_keys.len(),
-        sp_root_ca_cert,
         ias_root_ca_cert,
         auditor_public_keys,
         config.rpc_max_message_size


### PR DESCRIPTION
## Description

Related to #61. I optimized the TLS config cache related logic with the following changes.
- Simplify `get_tls_config` logic, changed the hash_map cached structure.
- Introduce `private_key_sha256` as an identify to CertKeyPair, making `get_ra_cert` return a simple CertKeyPair.
- Decouple `ecc_handle`  from the params of `fn gen_ecc_cert`.
- Split the contruction of cert_der and private_key_der in to two different functions.

I am still working the optimization, and will finally fix #61 in a descent way. 

Fixes # (issue)

## Type of change (select applied and DELETE the others)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How Has This Been Tested?
https://ci.mesalock-linux.org/m4sterchain/incubator-mesatee/84

## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
