### PR TITLE
RA no more panic

### DIFF
--- a/mesatee_core/src/lib.rs
+++ b/mesatee_core/src/lib.rs
@@ -71,7 +71,7 @@ pub fn init_service(name: &str) -> Result<()> {
         error!("Runtime config is not initialized");
         return Err(Error::from(ErrorKind::ECallError));
     }
-    crate::rpc::sgx::prelude();
+    crate::rpc::sgx::prelude()?;
 
     Ok(())
 }

--- a/mesatee_core/src/rpc/sgx/mod.rs
+++ b/mesatee_core/src/rpc/sgx/mod.rs
@@ -55,8 +55,10 @@ mod ra;
 
 // Export this function for sgx enclave initialization
 #[cfg(feature = "mesalock_sgx")]
-pub fn prelude() {
-    ra::get_ra_cert();
+pub fn prelude() -> Result<()> {
+    // Hard coded RACredential validity in seconds for all enclave.
+    // We may allow each enclave to setup its own validity in the future.
+    ra::init_ra_credential(86400u64)
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Description
This is a follow up of PR #190, and it finally resolves the issue of issue #61.

The RACache renewal logic is into two functions
- `ra::init_ra_credential` (returns a Result)
    - This function is called during the enclave initialization phase, the inner RA error (if any) would finally propagated to `_core::init_service`.
- `ra::get_current_ra_credential()`  (always returns a RACredential)
    - This function is called before each TLS handshake. If there is an inner RA error during the renewal process, we will not update the RACache. The existing (expired) RACredential is returned, which will lead to an TLS handshake error if the other side validate the target correctly.

## Type of change (select applied and DELETE the others)

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How Has This Been Tested?
https://ci.mesalock-linux.org/m4sterchain/incubator-mesatee/89
## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
