### PR TITLE
simple authentication service

### DIFF
--- a/services/authentication/enclave/Cargo.toml
+++ b/services/authentication/enclave/Cargo.toml
@@ -21,6 +21,7 @@ mesalock_sgx = [
   "teaclave_service_enclave_utils/mesalock_sgx",
   "teaclave_types/mesalock_sgx",
   "teaclave_config/mesalock_sgx",
+  "rusty-leveldb/mesalock_sgx",
 ]
 cov = ["teaclave_service_enclave_utils/cov"]
 enclave_unit_test = ["teaclave_ipc/enclave_unit_test", "sgx_tunittest"]
@@ -30,8 +31,14 @@ anyhow    = { version = "1.0.26" }
 cfg-if    = { version = "0.1.9" }
 log       = { version = "0.4.6" }
 serde     = { version = "1.0.92" }
-thiserror = { version = "1.0.9" }
+serde_json = { version = "1.0.39" }
 
+thiserror = { version = "1.0.9" }
+ring      = { version = "0.16.5" }
+rand      = { version = "0.7.0" }
+jsonwebtoken = { version = "6.0.1" }
+
+rusty-leveldb                  = { path = "../../../common/rusty_leveldb_sgx" }
 teaclave_attestation           = { path = "../../../attestation" }
 teaclave_config                = { path = "../../../config" }
 teaclave_proto                 = { path = "../../proto" }

--- a/services/authentication/enclave/src/lib.rs
+++ b/services/authentication/enclave/src/lib.rs
@@ -44,6 +44,8 @@ use teaclave_rpc::config::SgxTrustedTlsServerConfig;
 use teaclave_rpc::server::SgxTrustedTlsServer;
 
 mod service;
+mod user_db;
+mod user_info;
 
 #[handle_ecall]
 fn handle_start_service(args: &StartServiceInput) -> Result<StartServiceOutput> {
@@ -62,7 +64,9 @@ fn handle_start_service(args: &StartServiceInput) -> Result<StartServiceOutput> 
         TeaclaveAuthenticationResponse,
         TeaclaveAuthenticationRequest,
     >::new(listener, &config);
-    match server.start(service::TeaclaveAuthenticationService) {
+
+    let service = service::TeaclaveAuthenticationService::init().unwrap();
+    match server.start(service) {
         Ok(_) => (),
         Err(e) => {
             error!("Service exit, error: {}.", e);
@@ -99,7 +103,8 @@ pub mod tests {
     pub fn run_tests() -> usize {
         rsgx_unit_tests!(
             service::tests::test_user_login,
-            service::tests::test_user_authorize,
+            service::tests::test_user_authenticate,
+            service::tests::test_user_register,
         )
     }
 }

--- a/services/authentication/enclave/src/service.rs
+++ b/services/authentication/enclave/src/service.rs
@@ -1,7 +1,12 @@
+use crate::user_db::{DBClient, DBError, Database};
+use crate::user_info::{UserInfo, JWT_SECRET_LEN};
+use rand::prelude::RngCore;
 use std::prelude::v1::*;
+use std::time::{SystemTime, UNIX_EPOCH};
+use std::untrusted::time::SystemTimeEx;
 use teaclave_proto::teaclave_authentication_service::{
-    TeaclaveAuthentication, UserAuthorizeRequest, UserAuthorizeResponse, UserLoginRequest,
-    UserLoginResponse,
+    TeaclaveAuthentication, UserAuthenticateRequest, UserAuthenticateResponse, UserLoginRequest,
+    UserLoginResponse, UserRegisterRequest, UserRegisterResponse,
 };
 use teaclave_service_enclave_utils::teaclave_service;
 use teaclave_types::{TeaclaveServiceResponseError, TeaclaveServiceResponseResult};
@@ -11,6 +16,12 @@ use thiserror::Error;
 pub enum TeaclaveAuthenticationError {
     #[error("permission denied")]
     PermissionDenied,
+    #[error("invalid userid")]
+    InvalidUserid,
+    #[error("invalid password")]
+    InvalidPassword,
+    #[error("service unavailable")]
+    ServiceUnavailable,
 }
 
 impl From<TeaclaveAuthenticationError> for TeaclaveServiceResponseError {
@@ -25,78 +36,242 @@ impl From<TeaclaveAuthenticationError> for TeaclaveServiceResponseError {
     TeaclaveAuthenticationError
 )]
 #[derive(Clone)]
-pub(crate) struct TeaclaveAuthenticationService;
+pub(crate) struct TeaclaveAuthenticationService {
+    db_client: DBClient,
+    secret: [u8; JWT_SECRET_LEN],
+}
 
-impl TeaclaveAuthentication for TeaclaveAuthenticationService {
-    fn user_login(
-        &self,
-        _request: UserLoginRequest,
-    ) -> TeaclaveServiceResponseResult<UserLoginResponse> {
-        #[cfg(test_mode)]
-        return test_mode::mock_user_login(_request);
-
-        Err(TeaclaveAuthenticationError::PermissionDenied.into())
-    }
-
-    fn user_authorize(
-        &self,
-        _request: UserAuthorizeRequest,
-    ) -> TeaclaveServiceResponseResult<UserAuthorizeResponse> {
-        #[cfg(test_mode)]
-        return test_mode::mock_user_authorize(_request);
-
-        Err(TeaclaveAuthenticationError::PermissionDenied.into())
+impl TeaclaveAuthenticationService {
+    pub fn init() -> Option<Self> {
+        let database = match Database::open() {
+            Some(db) => db,
+            None => return None,
+        };
+        let mut secret = [0; JWT_SECRET_LEN];
+        let mut rng = rand::thread_rng();
+        rng.fill_bytes(&mut secret);
+        Some(Self {
+            db_client: database.get_client(),
+            secret,
+        })
     }
 }
 
-#[cfg(test_mode)]
-mod test_mode {
-    use super::*;
-    pub fn mock_user_login(
-        request: UserLoginRequest,
-    ) -> TeaclaveServiceResponseResult<UserLoginResponse> {
-        if request.id == "test_id" && request.password == "test_password" {
-            let response = UserLoginResponse {
-                token: "test_token".to_string(),
-            };
-            return Ok(response);
+impl TeaclaveAuthentication for TeaclaveAuthenticationService {
+    fn user_register(
+        &self,
+        request: UserRegisterRequest,
+    ) -> TeaclaveServiceResponseResult<UserRegisterResponse> {
+        if request.id.is_empty() {
+            return Err(TeaclaveAuthenticationError::InvalidUserid.into());
         }
-        Err(TeaclaveAuthenticationError::PermissionDenied.into())
+        if self.db_client.get_user(&request.id).is_ok() {
+            return Err(TeaclaveAuthenticationError::InvalidUserid.into());
+        }
+        let new_user = match UserInfo::new_register_user(&request.id, &request.password) {
+            Some(value) => value,
+            None => return Err(TeaclaveAuthenticationError::ServiceUnavailable.into()),
+        };
+        match self.db_client.create_user(&new_user) {
+            Ok(_) => Ok(UserRegisterResponse {}),
+            Err(DBError::UserExist) => Err(TeaclaveAuthenticationError::InvalidUserid.into()),
+            Err(_) => Err(TeaclaveAuthenticationError::ServiceUnavailable.into()),
+        }
     }
 
-    pub fn mock_user_authorize(
-        request: UserAuthorizeRequest,
-    ) -> TeaclaveServiceResponseResult<UserAuthorizeResponse> {
-        if request.credential.id == "test_id" && request.credential.token == "test_token" {
-            let response = UserAuthorizeResponse { accept: true };
-            return Ok(response);
+    fn user_login(
+        &self,
+        request: UserLoginRequest,
+    ) -> TeaclaveServiceResponseResult<UserLoginResponse> {
+        if request.id.is_empty() {
+            return Err(TeaclaveAuthenticationError::InvalidUserid.into());
         }
-        Err(TeaclaveAuthenticationError::PermissionDenied.into())
+        if request.password.is_empty() {
+            return Err(TeaclaveAuthenticationError::InvalidPassword.into());
+        }
+        let user: UserInfo = match self.db_client.get_user(&request.id) {
+            Ok(value) => value,
+            Err(_) => return Err(TeaclaveAuthenticationError::PermissionDenied.into()),
+        };
+        if !user.verify_password(&request.password) {
+            Err(TeaclaveAuthenticationError::PermissionDenied.into())
+        } else {
+            let now = match SystemTime::now().duration_since(UNIX_EPOCH) {
+                Ok(timestamp) => timestamp.as_secs() as i64,
+                Err(_) => return Err(TeaclaveAuthenticationError::ServiceUnavailable.into()),
+            };
+            let exp = now + 24 * 60;
+            match user.get_token(exp, &self.secret) {
+                Ok(token) => Ok(UserLoginResponse { token }),
+                Err(_) => Err(TeaclaveAuthenticationError::ServiceUnavailable.into()),
+            }
+        }
+    }
+
+    fn user_authenticate(
+        &self,
+        request: UserAuthenticateRequest,
+    ) -> TeaclaveServiceResponseResult<UserAuthenticateResponse> {
+        if request.credential.id.is_empty() || request.credential.token.is_empty() {
+            return Ok(UserAuthenticateResponse { accept: false });
+        }
+        let user: UserInfo = match self.db_client.get_user(&request.credential.id) {
+            Ok(value) => value,
+            Err(_) => return Ok(UserAuthenticateResponse { accept: false }),
+        };
+        Ok(UserAuthenticateResponse {
+            accept: user.validate_token(&self.secret, &request.credential.token),
+        })
     }
 }
 
 #[cfg(feature = "enclave_unit_test")]
 pub mod tests {
     use super::*;
+    use crate::user_info::*;
+    use std::vec;
     use teaclave_proto::teaclave_common::UserCredential;
 
-    pub fn test_user_login() {
-        let request = UserLoginRequest {
-            id: "test_id".to_string(),
-            password: "test_password".to_string(),
-        };
-        let service = TeaclaveAuthenticationService;
-        assert!(service.user_login(request).is_ok());
+    fn get_mock_service() -> TeaclaveAuthenticationService {
+        TeaclaveAuthenticationService::init().unwrap()
     }
 
-    pub fn test_user_authorize() {
-        let credential = UserCredential {
-            id: "test_id".to_string(),
-            token: "test_token".to_string(),
+    pub fn test_user_register() {
+        let request = UserRegisterRequest {
+            id: "test_register_id".to_string(),
+            password: "test_password".to_string(),
         };
+        let service = get_mock_service();
+        assert!(service.user_register(request).is_ok());
+    }
 
-        let request = UserAuthorizeRequest { credential };
-        let service = TeaclaveAuthenticationService;
-        assert!(service.user_authorize(request).is_ok());
+    pub fn test_user_login() {
+        let service = get_mock_service();
+        let request = UserRegisterRequest {
+            id: "test_login_id".to_string(),
+            password: "test_password".to_string(),
+        };
+        assert!(service.user_register(request).is_ok());
+        let request = UserLoginRequest {
+            id: "test_login_id".to_string(),
+            password: "test_password".to_string(),
+        };
+        assert!(service.user_login(request).is_ok());
+
+        info!(
+            "saved user_info: {:?}",
+            service.db_client.get_user("test_login_id").unwrap()
+        );
+        let request = UserLoginRequest {
+            id: "test_login_id".to_string(),
+            password: "test_password1".to_string(),
+        };
+        assert!(service.user_login(request).is_err());
+    }
+
+    pub fn test_user_authenticate() {
+        let id = "test_authenticate_id";
+        let service = get_mock_service();
+        let request = UserRegisterRequest {
+            id: id.to_string(),
+            password: "test_password".to_string(),
+        };
+        assert!(service.user_register(request).is_ok());
+
+        let request = UserLoginRequest {
+            id: id.to_string(),
+            password: "test_password".to_string(),
+        };
+        let token = service.user_login(request).unwrap().token;
+        info!("login token: {}", token);
+        dump_token(&service.secret, &token);
+
+        let response = get_authenticate_response(id, &token, &service);
+        assert!(response.accept);
+
+        info!("test wrong algorithm");
+        let my_claims = get_correct_claim();
+        let token = gen_token(
+            my_claims,
+            Some(jsonwebtoken::Algorithm::HS256),
+            &service.secret,
+        );
+        dump_token(&service.secret, &token);
+        let response = get_authenticate_response(id, &token, &service);
+        assert!(!response.accept);
+
+        info!("test wrong issuer");
+        let mut my_claims = get_correct_claim();
+        my_claims.iss = "wrong issuer".to_string();
+        let token = gen_token(my_claims, None, &service.secret);
+        dump_token(&service.secret, &token);
+        let response = get_authenticate_response(id, &token, &service);
+        assert!(!response.accept);
+
+        info!("test wrong user");
+        let mut my_claims = get_correct_claim();
+        my_claims.sub = "wrong user".to_string();
+        let token = gen_token(my_claims, None, &service.secret);
+        dump_token(&service.secret, &token);
+        let response = get_authenticate_response(id, &token, &service);
+        assert!(!response.accept);
+
+        info!("test expired token");
+        let mut my_claims = get_correct_claim();
+        my_claims.exp -= 24 * 60 + 1;
+        let token = gen_token(my_claims, None, &service.secret);
+        dump_token(&service.secret, &token);
+        let response = get_authenticate_response(id, &token, &service);
+        assert!(!response.accept);
+
+        info!("test wrong secret");
+        let my_claims = get_correct_claim();
+        let token = gen_token(my_claims, None, b"bad secret");
+        dump_token(&service.secret, &token);
+        let response = get_authenticate_response(id, &token, &service);
+        assert!(!response.accept);
+    }
+
+    fn get_correct_claim() -> Claims {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        Claims {
+            sub: "test_authenticate_id".to_string(),
+            iss: ISSUER_NAME.to_string(),
+            exp: now + 24 * 60,
+        }
+    }
+
+    fn gen_token(claim: Claims, bad_alg: Option<jsonwebtoken::Algorithm>, secret: &[u8]) -> String {
+        let mut header = jsonwebtoken::Header::default();
+        header.alg = bad_alg.unwrap_or(JWT_ALG);
+        jsonwebtoken::encode(&header, &claim, secret).unwrap()
+    }
+
+    fn get_authenticate_response(
+        id: &str,
+        token: &str,
+        service: &TeaclaveAuthenticationService,
+    ) -> UserAuthenticateResponse {
+        let credential = UserCredential {
+            id: id.to_string(),
+            token: token.to_string(),
+        };
+        let request = UserAuthenticateRequest { credential };
+        service.user_authenticate(request).unwrap()
+    }
+
+    fn dump_token(secret: &[u8], token: &str) {
+        let validation = jsonwebtoken::Validation {
+            iss: Some(ISSUER_NAME.to_string()),
+            sub: Some("test_authenticate_id".to_string()),
+            algorithms: vec![JWT_ALG],
+            ..Default::default()
+        };
+        let token_data =
+            jsonwebtoken::decode::<crate::user_info::Claims>(token, secret, &validation);
+        info!("token {:?}", token_data);
     }
 }

--- a/services/authentication/enclave/src/user_db.rs
+++ b/services/authentication/enclave/src/user_db.rs
@@ -1,0 +1,187 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::user_info::UserInfo;
+use rusty_leveldb::DB;
+use std::prelude::v1::*;
+use std::sync::mpsc::{channel, Sender};
+use std::thread;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DBError {
+    #[error("user not exist")]
+    UserNotExist,
+    #[error("user exist")]
+    UserExist,
+    #[error("mpsc error")]
+    MpscError,
+    #[error("leveldb error")]
+    LevelDbError,
+    #[error("invalid response")]
+    InvalidResponse,
+    #[error("invalid request")]
+    InvalidRequest,
+}
+
+#[derive(Clone)]
+struct GetRequest {
+    key: Vec<u8>,
+}
+#[derive(Clone)]
+struct GetResponse {
+    value: Vec<u8>,
+}
+
+#[derive(Clone)]
+struct CreateRequest {
+    key: Vec<u8>,
+    value: Vec<u8>,
+}
+
+#[derive(Clone)]
+enum DBRequest {
+    Get(GetRequest),
+    Create(CreateRequest),
+    Ping,
+}
+
+#[derive(Clone)]
+enum DBResponse {
+    Get(GetResponse),
+    Create,
+    Ping,
+}
+
+#[derive(Clone)]
+struct DBCall {
+    pub sender: Sender<Result<DBResponse, DBError>>,
+    pub request: DBRequest,
+}
+
+pub struct Database {
+    sender: Sender<DBCall>,
+}
+
+impl Database {
+    pub fn open() -> Option<Self> {
+        let (sender, receiver) = channel();
+        thread::spawn(move || {
+            let opt = rusty_leveldb::in_memory();
+            let mut database = DB::open("authentication_db", opt).unwrap();
+            loop {
+                let call: DBCall = match receiver.recv() {
+                    Ok(req) => req,
+                    Err(e) => {
+                        error!("mspc receive error: {}", e);
+                        break;
+                    }
+                };
+                let sender = call.sender;
+                let response = match call.request {
+                    DBRequest::Get(request) => match database.get(&request.key) {
+                        Some(value) => Ok(DBResponse::Get(GetResponse { value })),
+                        None => Err(DBError::UserNotExist),
+                    },
+                    DBRequest::Create(request) => match database.get(&request.key) {
+                        Some(_) => Err(DBError::UserExist),
+                        None => match database.put(&request.key, &request.value) {
+                            Ok(_) => Ok(DBResponse::Create),
+                            Err(_) => Err(DBError::LevelDbError),
+                        },
+                    },
+                    DBRequest::Ping => Ok(DBResponse::Ping),
+                };
+                match sender.send(response) {
+                    Ok(_) => (),
+                    Err(e) => error!("mpsc send error: {}", e),
+                }
+            }
+        });
+
+        let database = Self { sender };
+        let client = database.get_client();
+        // check whether the db is opened successfuly
+        match client.ping() {
+            Ok(_) => Some(database),
+            Err(_) => None,
+        }
+    }
+
+    pub fn get_client(&self) -> DBClient {
+        DBClient {
+            sender: self.sender.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct DBClient {
+    sender: Sender<DBCall>,
+}
+
+impl DBClient {
+    pub fn get_user(&self, id: &str) -> Result<UserInfo, DBError> {
+        let (sender, receiver) = channel();
+        let request = DBRequest::Get(GetRequest {
+            key: id.as_bytes().to_vec(),
+        });
+        let call = DBCall { sender, request };
+        self.sender.send(call).map_err(|_| DBError::MpscError)?;
+        let result = receiver.recv().map_err(|_| DBError::MpscError)?;
+        let db_response = result?;
+        match db_response {
+            DBResponse::Get(response) => {
+                let user = serde_json::from_slice(&response.value)
+                    .map_err(|_| DBError::InvalidResponse)?;
+                Ok(user)
+            }
+            _ => Err(DBError::UserNotExist),
+        }
+    }
+
+    pub fn create_user(&self, user: &UserInfo) -> Result<(), DBError> {
+        let (sender, receiver) = channel();
+        let user_bytes = serde_json::to_vec(&user).map_err(|_| DBError::InvalidRequest)?;
+        let request = DBRequest::Create(CreateRequest {
+            key: user.id.as_bytes().to_vec(),
+            value: user_bytes.to_vec(),
+        });
+        let call = DBCall { sender, request };
+        self.sender.send(call).map_err(|_| DBError::MpscError)?;
+        let result = receiver.recv().map_err(|_| DBError::MpscError)?;
+        let db_response = result?;
+        match db_response {
+            DBResponse::Create => Ok(()),
+            _ => Err(DBError::InvalidResponse),
+        }
+    }
+
+    // use to check whether the db is opened successfully
+    fn ping(&self) -> Result<(), DBError> {
+        let (sender, receiver) = channel();
+        let request = DBRequest::Ping;
+        let call = DBCall { sender, request };
+        self.sender.send(call).map_err(|_| DBError::MpscError)?;
+        let result = receiver.recv().map_err(|_| DBError::MpscError)?;
+        let db_response = result?;
+        match db_response {
+            DBResponse::Ping => Ok(()),
+            _ => Err(DBError::InvalidResponse),
+        }
+    }
+}

--- a/services/authentication/enclave/src/user_info.rs
+++ b/services/authentication/enclave/src/user_info.rs
@@ -1,0 +1,121 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use anyhow::Result;
+use jsonwebtoken::{self, Header, Validation};
+use rand::prelude::RngCore;
+use ring::{digest, pbkdf2};
+use serde::{Deserialize, Serialize};
+use std::num::NonZeroU32;
+use std::prelude::v1::*;
+use std::vec;
+
+const SALT_LEN: usize = 16;
+const PASS_LEN: usize = digest::SHA512_OUTPUT_LEN;
+static PBKDF2_ALG: ring::pbkdf2::Algorithm = pbkdf2::PBKDF2_HMAC_SHA512;
+const ITER_LEN: u32 = 100_000;
+pub const ISSUER_NAME: &str = "TeaClave";
+pub static JWT_ALG: jsonwebtoken::Algorithm = jsonwebtoken::Algorithm::HS512;
+pub const JWT_SECRET_LEN: usize = 512;
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct UserInfo {
+    pub id: String,
+    pub salt: Vec<u8>,                 // size is SALT_LEN
+    pub salted_password_hash: Vec<u8>, // size is PASS_LEN
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Claims {
+    // user id
+    pub sub: String,
+    // issuer: ISSUER_NAME
+    pub iss: String,
+    // expiration time
+    // (SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as i64 + some seconds)
+    pub exp: i64,
+}
+
+impl UserInfo {
+    pub fn new_register_user(id: &str, password: &str) -> Option<UserInfo> {
+        let mut rng = rand::thread_rng();
+        let mut salt: [u8; SALT_LEN] = [0; SALT_LEN];
+        rng.fill_bytes(&mut salt);
+        let mut salted_password_hash = [0; PASS_LEN];
+        let iter = match NonZeroU32::new(ITER_LEN) {
+            Some(value) => value,
+            None => return None,
+        };
+        pbkdf2::derive(
+            PBKDF2_ALG,
+            iter,
+            &salt,
+            password.as_bytes(),
+            &mut salted_password_hash,
+        );
+        Some(Self {
+            id: id.to_string(),
+            salt: salt.to_vec(),
+            salted_password_hash: salted_password_hash.to_vec(),
+        })
+    }
+
+    pub fn verify_password(&self, password: &str) -> bool {
+        let mut salt: [u8; SALT_LEN] = [0; SALT_LEN];
+        let mut salted_password_hash: [u8; PASS_LEN] = [0; PASS_LEN];
+        if self.salt.len() != SALT_LEN || self.salted_password_hash.len() != PASS_LEN {
+            return false;
+        }
+        let iter = match NonZeroU32::new(ITER_LEN) {
+            Some(value) => value,
+            None => return false,
+        };
+        salt.copy_from_slice(&self.salt[0..SALT_LEN]);
+        salted_password_hash.copy_from_slice(&self.salted_password_hash[0..PASS_LEN]);
+        pbkdf2::verify(
+            PBKDF2_ALG,
+            iter,
+            &salt,
+            password.as_bytes(),
+            &salted_password_hash,
+        )
+        .is_ok()
+    }
+
+    pub fn get_token(&self, exp: i64, secret: &[u8]) -> Result<String> {
+        let my_claims = Claims {
+            sub: self.id.clone(),
+            iss: ISSUER_NAME.to_string(),
+            exp,
+        };
+        let mut header = Header::default();
+        header.alg = JWT_ALG;
+        let token = jsonwebtoken::encode(&header, &my_claims, secret)?;
+        Ok(token)
+    }
+
+    pub fn validate_token(&self, secret: &[u8], token: &str) -> bool {
+        let validation = Validation {
+            iss: Some(ISSUER_NAME.to_string()),
+            sub: Some(self.id.to_string()),
+            algorithms: vec![JWT_ALG],
+            ..Default::default()
+        };
+        let token_data = jsonwebtoken::decode::<Claims>(token, secret, &validation);
+        token_data.is_ok()
+    }
+}

--- a/services/database/enclave/src/service.rs
+++ b/services/database/enclave/src/service.rs
@@ -143,7 +143,7 @@ impl TeaclaveDatabaseService {
                 Ok(req) => req,
                 Err(e) => {
                     error!("mspc receive error: {}", e);
-                    continue;
+                    break;
                 }
             };
             let database_request = request.request;

--- a/services/proto/src/proto/teaclave_authentication_service.proto
+++ b/services/proto/src/proto/teaclave_authentication_service.proto
@@ -3,6 +3,14 @@ package teaclave_authentication_service_proto;
 
 import "teaclave_common.proto";
 
+message UserRegisterRequest {
+  string id = 1;
+  string password = 2;
+}
+
+message UserRegisterResponse {
+}
+
 message UserLoginRequest {
   string id = 1;
   string password = 2;
@@ -12,15 +20,16 @@ message UserLoginResponse {
   string token = 1;
 }
 
-message UserAuthorizeRequest {
+message UserAuthenticateRequest {
   teaclave_common_proto.UserCredential credential = 1;
 }
 
-message UserAuthorizeResponse {
+message UserAuthenticateResponse {
   bool accept = 1;
 }
 
 service TeaclaveAuthentication {
+  rpc UserRegister(UserRegisterRequest) returns (UserRegisterResponse);
   rpc UserLogin (UserLoginRequest) returns (UserLoginResponse);
-  rpc UserAuthorize (UserAuthorizeRequest) returns (UserAuthorizeResponse);
+  rpc UserAuthenticate (UserAuthenticateRequest) returns (UserAuthenticateResponse);
 }

--- a/services/proto/src/teaclave_authentication_service.rs
+++ b/services/proto/src/teaclave_authentication_service.rs
@@ -10,6 +10,15 @@ pub use proto::TeaclaveAuthenticationRequest;
 pub use proto::TeaclaveAuthenticationResponse;
 
 #[derive(serde_derive::Serialize, serde_derive::Deserialize, Debug)]
+pub struct UserRegisterRequest {
+    pub id: std::string::String,
+    pub password: std::string::String,
+}
+
+#[derive(serde_derive::Serialize, serde_derive::Deserialize, Debug)]
+pub struct UserRegisterResponse {}
+
+#[derive(serde_derive::Serialize, serde_derive::Deserialize, Debug)]
 pub struct UserLoginRequest {
     pub id: std::string::String,
     pub password: std::string::String,
@@ -21,13 +30,49 @@ pub struct UserLoginResponse {
 }
 
 #[derive(serde_derive::Serialize, serde_derive::Deserialize, Debug)]
-pub struct UserAuthorizeRequest {
+pub struct UserAuthenticateRequest {
     pub credential: teaclave_common::UserCredential,
 }
 
 #[derive(serde_derive::Serialize, serde_derive::Deserialize, Debug)]
-pub struct UserAuthorizeResponse {
+pub struct UserAuthenticateResponse {
     pub accept: bool,
+}
+
+impl std::convert::TryFrom<proto::UserRegisterRequest> for UserRegisterRequest {
+    type Error = Error;
+
+    fn try_from(proto: proto::UserRegisterRequest) -> Result<Self> {
+        let ret = Self {
+            id: proto.id,
+            password: proto.password,
+        };
+
+        Ok(ret)
+    }
+}
+
+impl From<UserRegisterRequest> for proto::UserRegisterRequest {
+    fn from(request: UserRegisterRequest) -> Self {
+        Self {
+            id: request.id,
+            password: request.password,
+        }
+    }
+}
+
+impl std::convert::TryFrom<proto::UserRegisterResponse> for UserRegisterResponse {
+    type Error = Error;
+
+    fn try_from(_reponse: proto::UserRegisterResponse) -> Result<Self> {
+        Ok(Self {})
+    }
+}
+
+impl From<UserRegisterResponse> for proto::UserRegisterResponse {
+    fn from(_response: UserRegisterResponse) -> Self {
+        Self {}
+    }
 }
 
 impl std::convert::TryFrom<proto::UserLoginRequest> for UserLoginRequest {
@@ -60,10 +105,10 @@ impl From<UserLoginResponse> for proto::UserLoginResponse {
     }
 }
 
-impl std::convert::TryFrom<proto::UserAuthorizeRequest> for UserAuthorizeRequest {
+impl std::convert::TryFrom<proto::UserAuthenticateRequest> for UserAuthenticateRequest {
     type Error = Error;
 
-    fn try_from(proto: proto::UserAuthorizeRequest) -> Result<Self> {
+    fn try_from(proto: proto::UserAuthenticateRequest) -> Result<Self> {
         let ret = Self {
             credential: proto
                 .credential
@@ -75,16 +120,16 @@ impl std::convert::TryFrom<proto::UserAuthorizeRequest> for UserAuthorizeRequest
     }
 }
 
-impl From<UserAuthorizeRequest> for proto::UserAuthorizeRequest {
-    fn from(request: UserAuthorizeRequest) -> Self {
+impl From<UserAuthenticateRequest> for proto::UserAuthenticateRequest {
+    fn from(request: UserAuthenticateRequest) -> Self {
         Self {
             credential: Some(request.credential.into()),
         }
     }
 }
 
-impl From<UserAuthorizeResponse> for proto::UserAuthorizeResponse {
-    fn from(response: UserAuthorizeResponse) -> Self {
+impl From<UserAuthenticateResponse> for proto::UserAuthenticateResponse {
+    fn from(response: UserAuthenticateResponse) -> Self {
         Self {
             accept: response.accept,
         }

--- a/services/proto/src/teaclave_database_service.rs
+++ b/services/proto/src/teaclave_database_service.rs
@@ -80,9 +80,9 @@ impl std::convert::TryFrom<proto::GetResponse> for GetResponse {
 }
 
 impl From<GetResponse> for proto::GetResponse {
-    fn from(request: GetResponse) -> Self {
+    fn from(response: GetResponse) -> Self {
         Self {
-            value: request.value,
+            value: response.value,
         }
     }
 }
@@ -118,7 +118,7 @@ impl std::convert::TryFrom<proto::PutResponse> for PutResponse {
 }
 
 impl From<PutResponse> for proto::PutResponse {
-    fn from(_request: PutResponse) -> Self {
+    fn from(_response: PutResponse) -> Self {
         Self {}
     }
 }
@@ -148,7 +148,7 @@ impl std::convert::TryFrom<proto::DeleteResponse> for DeleteResponse {
 }
 
 impl From<DeleteResponse> for proto::DeleteResponse {
-    fn from(_request: DeleteResponse) -> Self {
+    fn from(_response: DeleteResponse) -> Self {
         Self {}
     }
 }
@@ -184,7 +184,7 @@ impl std::convert::TryFrom<proto::EnqueueResponse> for EnqueueResponse {
 }
 
 impl From<EnqueueResponse> for proto::EnqueueResponse {
-    fn from(_request: EnqueueResponse) -> Self {
+    fn from(_response: EnqueueResponse) -> Self {
         Self {}
     }
 }
@@ -214,9 +214,9 @@ impl std::convert::TryFrom<proto::DequeueResponse> for DequeueResponse {
 }
 
 impl From<DequeueResponse> for proto::DequeueResponse {
-    fn from(request: DequeueResponse) -> Self {
+    fn from(response: DequeueResponse) -> Self {
         Self {
-            value: request.value,
+            value: response.value,
         }
     }
 }

--- a/tests/unit_tests/enclave/src/lib.rs
+++ b/tests/unit_tests/enclave/src/lib.rs
@@ -40,10 +40,9 @@ use teaclave_execution_service_enclave;
 
 #[handle_ecall]
 fn handle_run_test(_args: &RunTestInput) -> Result<RunTestOutput> {
-    teaclave_authentication_service_enclave::tests::run_tests();
     teaclave_database_service_enclave::tests::run_tests();
     teaclave_execution_service_enclave::tests::run_tests();
-
+    teaclave_authentication_service_enclave::tests::run_tests();
     Ok(RunTestOutput::default())
 }
 


### PR DESCRIPTION
## Description

Simple authentication service:
1. use pbkdf2 to protect password
2. use rusty_leveldb to save password
3. use json web token to generate and verify authentication token

Fixes # (issue)

## Type of change (select applied and DELETE the others)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How Has This Been Tested?

## Checklist (check ALL before submitting PR, even not applicable)

- [ ] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the tests pass (see CI results).
- [ ] Make sure your code lints/format.
