### PR TITLE
Make teaclave compatible with sgx 2.8

### DIFF
--- a/common/protected_fs_rs/protected_fs_c/inc/non_sgx_protected_fs.h
+++ b/common/protected_fs_rs/protected_fs_c/inc/non_sgx_protected_fs.h
@@ -47,15 +47,6 @@ typedef struct _sgx_cpu_svn_t
     uint8_t                        svn[SGX_CPUSVN_SIZE];
 } sgx_cpu_svn_t;
 
-// defined in sgx_tae_service.h
-#define SGX_MC_UUID_COUNTER_ID_SIZE 3
-#define SGX_MC_UUID_NONCE_SIZE      13
-typedef struct _mc_uuid {
-    uint8_t counter_id[SGX_MC_UUID_COUNTER_ID_SIZE];
-    uint8_t nonce[SGX_MC_UUID_NONCE_SIZE];
-} sgx_mc_uuid_t;
-
-
 // sgx_attributes.h
 typedef struct _attributes_t
 {

--- a/common/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/protected_fs_nodes.h
+++ b/common/protected_fs_rs/protected_fs_c/sgx_tprotected_fs/protected_fs_nodes.h
@@ -28,7 +28,6 @@
 #else
 #include <sgx_report.h>
 #include <sgx_tcrypto.h>
-#include <sgx_tae_service.h>
 #endif
 
 #pragma pack(push, 1)
@@ -67,6 +66,10 @@ typedef struct _meta_data_plain
 #define FILENAME_MAX_LEN  260
 #define MD_USER_DATA_SIZE (NODE_SIZE*3/4)  // 3072
 COMPILE_TIME_ASSERT(md_user_data_size, MD_USER_DATA_SIZE == 3072);
+
+typedef struct _mc_uuid {
+    uint8_t mc_uuid[16];
+} sgx_mc_uuid_t;
 
 typedef struct _meta_data_encrypted
 {


### PR DESCRIPTION
## Description

Make teaclave compatible with sgx 2.8.
This patch is backward-compatible.
To work under sgx 2.8, struct global_data_t needs to be patched for crates-io & crates-sgx.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Yes
## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
