### PR TITLE
docs(attestation): fix a typo and add some doc

### DIFF
--- a/attestation/src/attestation.rs
+++ b/attestation/src/attestation.rs
@@ -63,7 +63,7 @@ impl RemoteAttestation {
 
 impl AttestedTlsConfig {
     fn new(attestation_config: &AttestationConfig) -> Result<AttestedTlsConfig> {
-        let key_pair = key::Secp256k1KeyPair::new()?;
+        let key_pair = key::NistP256KeyPair::new()?;
         let report = match attestation_config {
             AttestationConfig::NoAttestation => EndorsedAttestationReport::default(),
             AttestationConfig::WithAttestation(config) => {

--- a/attestation/src/key.rs
+++ b/attestation/src/key.rs
@@ -22,12 +22,14 @@ use std::prelude::v1::*;
 
 pub const CERT_VALID_DAYS: i64 = 90i64;
 
-pub struct Secp256k1KeyPair {
+/// NistP256KeyPair stores a pair of ECDSA (private, public) key based on the NIST P-256 curve 
+/// (a.k.a secp256r1).
+pub struct NistP256KeyPair {
     prv_k: sgx_ec256_private_t,
     pub pub_k: sgx_ec256_public_t,
 }
 
-impl Secp256k1KeyPair {
+impl NistP256KeyPair {
     pub fn new() -> Result<Self> {
         let ecc_handle = SgxEccHandle::new();
         ecc_handle.open()?;
@@ -70,6 +72,11 @@ impl Secp256k1KeyPair {
         })
     }
 
+    /// create_cert_with_extension makes a self-signed x509-v3 cert with SGX attestation report as
+    /// extensions.
+    /// @reference [Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile][1]
+    /// 
+    /// [1]: https://tools.ietf.org/pdf/rfc5280.pdf
     pub fn create_cert_with_extension(
         &self,
         issuer: &str,

--- a/attestation/src/platform.rs
+++ b/attestation/src/platform.rs
@@ -149,14 +149,14 @@ pub mod tests {
 
     fn test_create_sgx_isv_enclave_report() {
         let (_ak_id, qe_target_info) = init_sgx_quote().unwrap();
-        let key_pair = key::Secp256k1KeyPair::new().unwrap();
+        let key_pair = key::NistP256KeyPair::new().unwrap();
         let sgx_report_result = create_sgx_isv_enclave_report(key_pair.pub_k, qe_target_info);
         assert!(sgx_report_result.is_ok());
     }
 
     fn test_get_sgx_quote() {
         let (ak_id, qe_target_info) = init_sgx_quote().unwrap();
-        let key_pair = key::Secp256k1KeyPair::new().unwrap();
+        let key_pair = key::NistP256KeyPair::new().unwrap();
         let sgx_report = create_sgx_isv_enclave_report(key_pair.pub_k, qe_target_info).unwrap();
         let quote_result = get_sgx_quote(&ak_id, sgx_report);
         assert!(quote_result.is_ok());


### PR DESCRIPTION
## Description

The built-in ECDSA is based on NIST P-256 (a.k.a. secp256r1), not secp256k1. This PR just fix that typo~

Relevant line of codes is https://github.com/apache/incubator-teaclave/blob/develop/attestation/src/key.rs#L25 

## Type of change (select applied and DELETE the others)

- API change with a documentation update

## How Has This Been Tested?

Document changed only~

## Checklist (check ALL before submitting PR, even not applicable)

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
