### PR TITLE
Make building build.rs offline using vendored crates

### DIFF
--- a/config/build.config.toml
+++ b/config/build.config.toml
@@ -1,15 +1,15 @@
 # Teaclave Build Config
 
 # Intel Attestation Service root CA certificate to verify attestation report
-as_root_ca_cert = { path = "../keys/ias_root_ca_cert.pem" }
+as_root_ca_cert = { path = "keys/ias_root_ca_cert.pem" }
 # For DCAP, use the following cert
-# as_root_ca_cert = { path = "../keys/dcap_root_ca_cert.pem" }
+# as_root_ca_cert = { path = "keys/dcap_root_ca_cert.pem" }
 
 # Auditors' public keys to verify their endorsement signatures
 auditor_public_keys = [
-    { path = "../keys/auditors/godzilla/godzilla.public.pem" },
-    { path = "../keys/auditors/optimus_prime/optimus_prime.public.pem" },
-    { path = "../keys/auditors/albus_dumbledore/albus_dumbledore.public.pem"},
+    { path = "keys/auditors/godzilla/godzilla.public.pem" },
+    { path = "keys/auditors/optimus_prime/optimus_prime.public.pem" },
+    { path = "keys/auditors/albus_dumbledore/albus_dumbledore.public.pem"},
 ]
 
 # RPC max message size

--- a/config/build.rs
+++ b/config/build.rs
@@ -36,16 +36,19 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     let target_dir = Path::new(&env::var("TEACLAVE_SYMLINKS").expect("TEACLAVE_SYMLINKS"))
         .join("teaclave_build/target/config_gen");
+    let unix_toml_dir = env::var("MT_SGXAPP_TOML_DIR").expect("MT_SGXAPP_TOML_DIR");
     let c = Command::new("cargo")
+        .current_dir(&unix_toml_dir)
         .args(&[
             "run",
             "--target-dir",
             &target_dir.to_string_lossy(),
             "--manifest-path",
-            "config_gen/Cargo.toml",
+            "config/config_gen/Cargo.toml",
+            "--offline",
             "--",
             "-t",
-            "build.config.toml",
+            "config/build.config.toml",
             "-o",
             &dest_file.to_string_lossy(),
         ])

--- a/config/config_gen/Cargo.toml
+++ b/config/config_gen/Cargo.toml
@@ -16,3 +16,5 @@ structopt = "0.3"
 pem = "0.7.0"
 serde = { version = "1.0.92", features = ["derive"] }
 toml = "0.5.1"
+
+[workspace]

--- a/services/proto/build.rs
+++ b/services/proto/build.rs
@@ -22,13 +22,13 @@ use std::str;
 
 fn main() {
     let proto_files = [
-        "src/proto/teaclave_access_control_service.proto",
-        "src/proto/teaclave_authentication_service.proto",
-        "src/proto/teaclave_common.proto",
-        "src/proto/teaclave_storage_service.proto",
-        "src/proto/teaclave_frontend_service.proto",
-        "src/proto/teaclave_management_service.proto",
-        "src/proto/teaclave_scheduler_service.proto",
+        "services/proto/src/proto/teaclave_access_control_service.proto",
+        "services/proto/src/proto/teaclave_authentication_service.proto",
+        "services/proto/src/proto/teaclave_common.proto",
+        "services/proto/src/proto/teaclave_storage_service.proto",
+        "services/proto/src/proto/teaclave_frontend_service.proto",
+        "services/proto/src/proto/teaclave_management_service.proto",
+        "services/proto/src/proto/teaclave_scheduler_service.proto",
     ];
 
     let out_dir = env::var("OUT_DIR").expect("$OUT_DIR not set. Please build with cargo");
@@ -42,16 +42,19 @@ fn main() {
 
     let target_dir = Path::new(&env::var("TEACLAVE_SYMLINKS").expect("TEACLAVE_SYMLINKS"))
         .join("teaclave_build/target/proto_gen");
+    let unix_toml_dir = env::var("MT_SGXAPP_TOML_DIR").expect("MT_SGXAPP_TOML_DIR");
     let c = Command::new("cargo")
+        .current_dir(&unix_toml_dir)
         .args(&[
             "run",
             "--target-dir",
             &target_dir.to_string_lossy(),
             "--manifest-path",
-            "./proto_gen/Cargo.toml",
+            "services/proto/proto_gen/Cargo.toml",
+            "--offline",
             "--",
             "-i",
-            "src/proto",
+            "services/proto/src/proto",
             "-d",
             &out_dir,
             "-p",

--- a/services/proto/proto_gen/Cargo.toml
+++ b/services/proto/proto_gen/Cargo.toml
@@ -16,3 +16,5 @@ prost-build = { version = "0.6.0" }
 prost       = { version = "0.6.0" }
 prost-types = { version = "0.6.0" }
 askama      = { version = "0.8" }
+
+[workspace]


### PR DESCRIPTION
## Description

This PR makes building build.rs offline using vendored crates.

Fix #181

CI: https://ci.mesalock-linux.org/mssun/incubator-mesatee/725