### PR TITLE
Format/lint all python code

### DIFF
--- a/cmake/scripts/gen_enclave_info_toml.py
+++ b/cmake/scripts/gen_enclave_info_toml.py
@@ -1,10 +1,12 @@
 import sys
 
+
 def find_hex_value(content, section):
     index = content.index(section)
     # assume each element in content is ending with '\n'
     hex_bytes = ''.join(content[index+1:index+3]).split()
     return ''.join(['%02x' % int(x, 16) for x in hex_bytes])
+
 
 mr_signer = "mrsigner->value:\n"
 mr_enclave = "metadata->enclave_css.body.enclave_hash.m:\n"

--- a/services/access_control/python/acs_engine_test.py
+++ b/services/access_control/python/acs_engine_test.py
@@ -20,15 +20,15 @@ if __name__ == '__main__':
     IRRELEVANT_TASK           = "task_irrelevant"
     IRRELEVANT_PARTY          = "usr_irrelevant"
     IRRELEVANT_DATA           = "data_irrelevant"
-    
+
     acs_announce_fact('task_creator', repr([FUSION_TASK, FUSION_TASK_PARTY_1]))
     acs_announce_fact('task_participant', repr([FUSION_TASK, FUSION_TASK_PARTY_1]))
     acs_announce_fact('task_participant', repr([FUSION_TASK, FUSION_TASK_PARTY_2]))
-    
+
     acs_announce_fact('data_owner', repr([FUSION_TASK_DATA_1, FUSION_TASK_PARTY_1]))
     acs_announce_fact('data_owner', repr([FUSION_TASK_DATA_2, FUSION_TASK_PARTY_2]))
     acs_announce_fact('data_owner', repr([IRRELEVANT_DATA, IRRELEVANT_PARTY]))
-    
+
     acs_announce_fact('script_owner', repr([FUSION_TASK_SCRIPT, FUSION_TASK_SCRIPT_WRITER]))
 
     acs_announce_fact('script_owner', repr([PUBLIC_SCRIPT, PUBLIC_SCRIPT_WRITER]))
@@ -39,14 +39,14 @@ if __name__ == '__main__':
     assert not acs_enforce_request('launch_task', repr([FUSION_TASK, set()]))
     assert not acs_enforce_request('launch_task', repr([FUSION_TASK, set([FUSION_TASK_PARTY_1])]))
     assert not acs_enforce_request('launch_task', repr([FUSION_TASK, set([FUSION_TASK_PARTY_2])]))
-    
+
     assert acs_enforce_request('access_data', repr([FUSION_TASK, FUSION_TASK_DATA_1]))
     assert acs_enforce_request('access_data', repr([FUSION_TASK, FUSION_TASK_DATA_2]))
     assert not acs_enforce_request('access_data', repr([FUSION_TASK, IRRELEVANT_DATA]))
 
     assert acs_enforce_request('access_script', repr([FUSION_TASK, PUBLIC_SCRIPT]))
     assert not acs_enforce_request('access_script', repr([FUSION_TASK, FUSION_TASK_SCRIPT]))
-    
+
     acs_announce_fact('task_participant', repr([FUSION_TASK, FUSION_TASK_SCRIPT_WRITER]))
     assert acs_enforce_request('access_script', repr([FUSION_TASK, FUSION_TASK_SCRIPT]))
 
@@ -56,7 +56,7 @@ if __name__ == '__main__':
     acs_announce_fact('task_creator', repr([IRRELEVANT_TASK, IRRELEVANT_PARTY]))
     acs_announce_fact('task_participant', repr([IRRELEVANT_TASK, IRRELEVANT_PARTY]))
     acs_announce_fact('task_participant', repr([IRRELEVANT_TASK, FUSION_TASK_PARTY_2]))
-    
+
     assert acs_enforce_request('launch_task', repr([IRRELEVANT_TASK, set([IRRELEVANT_PARTY, FUSION_TASK_PARTY_2])]))
     assert not acs_enforce_request('access_data', repr([IRRELEVANT_TASK, FUSION_TASK_DATA_1]))
     assert acs_enforce_request('access_data', repr([IRRELEVANT_TASK, FUSION_TASK_DATA_2]))

--- a/services/access_control/python/ffi.py
+++ b/services/access_control/python/ffi.py
@@ -5,9 +5,9 @@ import _cffi_backend as backend
 ffi = sgx_cffi.FFI(backend)
 
 ffi.embedding_api("int acs_setup_model(const char *configuration);")
-ffi.embedding_api("""int acs_enforce_request(const char *request_type, 
+ffi.embedding_api("""int acs_enforce_request(const char *request_type,
                                              const char *request_content);""")
-ffi.embedding_api("""int acs_announce_fact(const char *term_type, 
+ffi.embedding_api("""int acs_announce_fact(const char *term_type,
                                            const char *term_fact);""")
 with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "acs_engine.py")) as f:
     ffi.embedding_init_code(f.read())

--- a/tests/scripts/simple_http_server.py
+++ b/tests/scripts/simple_http_server.py
@@ -1,5 +1,5 @@
 import SimpleHTTPServer
-import BaseHTTPServer
+
 
 class HTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
     def do_PUT(self):


### PR DESCRIPTION
## Description

- Format/lint all python code. (basic style formatting)

Fix  #75.

CI: https://ci.mesalock-linux.org/mssun/incubator-mesatee/727