### PR TITLE
Fix wording

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,8 +1,8 @@
 Apache Teaclave (incubating) is an effort undergoing incubation at The Apache
-Software Foundation (ASF), sponsored by the name of Apache Incubator PMC.
+Software Foundation (ASF), sponsored by the Apache Incubator.
 Incubation is required of all newly accepted projects until a further review
 indicates that the infrastructure, communications, and decision making process
-have stabilized in a manner consistent with other successful ASF projects. While
-incubation status is not necessarily a reflection of the completeness or
+have stabilized in a manner consistent with other successful ASF projects.
+While incubation status is not necessarily a reflection of the completeness or
 stability of the code, it does indicate that the project has yet to be fully
 endorsed by the ASF.


### PR DESCRIPTION
## Description

Fix disclaimer wording: "sponsored by the name of Apache Incubator PMC" => "sponsored by the Apache Incubator"