### PR TITLE
Use json type for function arguments instead of string/string hashmap

### DIFF
--- a/function/src/gbdt_train.rs
+++ b/function/src/gbdt_train.rs
@@ -159,15 +159,15 @@ pub mod tests {
 
     fn test_gbdt_train() {
         let arguments = FunctionArguments::from_json(json!({
-            "feature_size"                : 4,
-            "max_depth"                   : 4,
-            "iterations"                  : 100,
-            "shrinkage"                   : 0.1,
-            "feature_sample_ratio"        : 1.0,
-            "data_sample_ratio"           : 1.0,
-            "min_leaf_size"               : 1,
-            "loss"                        : "LAD",
-            "training_optimization_level" : 2
+            "feature_size": 4,
+            "max_depth": 4,
+            "iterations": 100,
+            "shrinkage": 0.1,
+            "feature_sample_ratio": 1.0,
+            "data_sample_ratio": 1.0,
+            "min_leaf_size": 1,
+            "loss": "LAD",
+            "training_optimization_level": 2
         }))
         .unwrap();
 

--- a/sdk/python/teaclave.py
+++ b/sdk/python/teaclave.py
@@ -158,6 +158,7 @@ class FrontendClient:
                     executor,
                     inputs_ownership=[],
                     outputs_ownership=[]):
+        function_arguments = json.dumps(function_arguments)
         request = CreateTaskRequest(self.metadata, function_id,
                                     function_arguments, executor,
                                     inputs_ownership, outputs_ownership)

--- a/services/execution/enclave/src/service.rs
+++ b/services/execution/enclave/src/service.rs
@@ -177,6 +177,7 @@ fn finalize_task(file_mgr: &TaskFileManager) -> Result<HashMap<String, FileAuthT
 #[cfg(feature = "enclave_unit_test")]
 pub mod tests {
     use super::*;
+    use serde_json::json;
     use std::format;
     use teaclave_crypto::*;
     use url::Url;
@@ -184,11 +185,13 @@ pub mod tests {
 
     pub fn test_invoke_echo() {
         let task_id = Uuid::new_v4();
+        let function_arguments =
+            FunctionArguments::from_json(json!({"message": "Hello, Teaclave!"})).unwrap();
         let staged_task = StagedTask::new()
             .task_id(task_id)
             .executor(Executor::Builtin)
             .function_name("builtin-echo")
-            .function_arguments(hashmap!("message" => "Hello, Teaclave!"));
+            .function_arguments(function_arguments);
 
         let file_mgr = TaskFileManager::new(
             WORKER_BASE_DIR,
@@ -210,17 +213,18 @@ pub mod tests {
 
     pub fn test_invoke_gbdt_train() {
         let task_id = Uuid::new_v4();
-        let function_arguments = FunctionArguments::new(hashmap!(
-            "feature_size"                => "4",
-            "max_depth"                   => "4",
-            "iterations"                  => "100",
-            "shrinkage"                   => "0.1",
-            "feature_sample_ratio"        => "1.0",
-            "data_sample_ratio"           => "1.0",
-            "min_leaf_size"               => "1",
-            "loss"                        => "LAD",
-            "training_optimization_level" => "2",
-        ));
+        let function_arguments = FunctionArguments::from_json(json!({
+            "feature_size": 4,
+            "max_depth": 4,
+            "iterations": 100,
+            "shrinkage": 0.1,
+            "feature_sample_ratio": 1.0,
+            "data_sample_ratio": 1.0,
+            "min_leaf_size": 1,
+            "loss": "LAD",
+            "training_optimization_level": 2,
+        }))
+        .unwrap();
         let fixture_dir = format!(
             "file:///{}/fixtures/functions/gbdt_training",
             env!("TEACLAVE_TEST_INSTALL_DIR")

--- a/services/management/enclave/src/service.rs
+++ b/services/management/enclave/src/service.rs
@@ -576,6 +576,7 @@ impl TeaclaveManagementService {
 #[cfg(feature = "enclave_unit_test")]
 pub mod tests {
     use super::*;
+    use serde_json::json;
     use std::collections::HashMap;
     use teaclave_types::{
         hashmap, Executor, FileAuthTag, FileCrypto, FunctionArguments, FunctionInput,
@@ -631,7 +632,7 @@ pub mod tests {
             .arguments(vec!["arg".to_string()])
             .public(true)
             .owner("mock_user");
-        let function_arguments = FunctionArguments::new(hashmap!("arg" => "data"));
+        let function_arguments = FunctionArguments::from_json(json!({"arg": "data"})).unwrap();
 
         let task = Task::<Create>::new(
             UserID::from("mock_user"),

--- a/services/proto/src/proto/teaclave_frontend_service.proto
+++ b/services/proto/src/proto/teaclave_frontend_service.proto
@@ -110,7 +110,7 @@ message DataMap {
 
 message CreateTaskRequest {
   string function_id = 1;
-  map<string, string> function_arguments = 2;
+  string function_arguments = 2;
   string executor = 3;
   repeated OwnerList inputs_ownership = 10;
   repeated OwnerList outputs_ownership= 11;
@@ -129,7 +129,7 @@ message GetTaskResponse {
   string creator = 2;
   string function_id = 3;
   string function_owner = 4;
-  map<string, string> function_arguments = 5;
+  string function_arguments = 5;
   repeated OwnerList inputs_ownership = 6;
   repeated OwnerList outputs_ownership = 7;
   repeated string participants = 8;

--- a/services/proto/src/teaclave_frontend_service.rs
+++ b/services/proto/src/teaclave_frontend_service.rs
@@ -958,7 +958,7 @@ impl std::convert::TryFrom<proto::CreateTaskRequest> for CreateTaskRequest {
     type Error = Error;
 
     fn try_from(proto: proto::CreateTaskRequest) -> Result<Self> {
-        let function_arguments = proto.function_arguments.into();
+        let function_arguments: FunctionArguments = proto.function_arguments.try_into()?;
         let inputs_ownership = from_proto_ownership(proto.inputs_ownership);
         let outputs_ownership = from_proto_ownership(proto.outputs_ownership);
         let function_id = proto.function_id.try_into()?;
@@ -977,7 +977,7 @@ impl std::convert::TryFrom<proto::CreateTaskRequest> for CreateTaskRequest {
 
 impl From<CreateTaskRequest> for proto::CreateTaskRequest {
     fn from(request: CreateTaskRequest) -> Self {
-        let function_arguments = request.function_arguments.into();
+        let function_arguments = request.function_arguments.into_string();
         let inputs_ownership = to_proto_ownership(request.inputs_ownership);
         let outputs_ownership = to_proto_ownership(request.outputs_ownership);
 
@@ -1054,7 +1054,7 @@ impl std::convert::TryFrom<proto::GetTaskResponse> for GetTaskResponse {
     type Error = Error;
 
     fn try_from(proto: proto::GetTaskResponse) -> Result<Self> {
-        let function_arguments = proto.function_arguments.into();
+        let function_arguments: FunctionArguments = proto.function_arguments.try_into()?;
         let inputs_ownership = from_proto_ownership(proto.inputs_ownership);
         let outputs_ownership = from_proto_ownership(proto.outputs_ownership);
         let assigned_inputs = from_proto_file_ids(proto.assigned_inputs)?;
@@ -1086,7 +1086,7 @@ impl std::convert::TryFrom<proto::GetTaskResponse> for GetTaskResponse {
 
 impl From<GetTaskResponse> for proto::GetTaskResponse {
     fn from(response: GetTaskResponse) -> Self {
-        let function_arguments = response.function_arguments.into();
+        let function_arguments = response.function_arguments.into_string();
         let inputs_ownership = to_proto_ownership(response.inputs_ownership);
         let outputs_ownership = to_proto_ownership(response.outputs_ownership);
         let assigned_inputs = to_proto_file_ids(response.assigned_inputs);

--- a/tests/functional/enclave/src/end_to_end/builtin_gbdt_train.rs
+++ b/tests/functional/enclave/src/end_to_end/builtin_gbdt_train.rs
@@ -103,20 +103,22 @@ fn create_gbdt_training_task(
     client: &mut TeaclaveFrontendClient,
     function_id: &ExternalID,
 ) -> ExternalID {
+    let arguments = FunctionArguments::from_json(serde_json::json!({
+        "feature_size": 4,
+        "max_depth": 4,
+        "iterations": 100,
+        "shrinkage": 0.1,
+        "feature_sample_ratio": 1.0,
+        "data_sample_ratio": 1.0,
+        "min_leaf_size": 1,
+        "loss": "LAD",
+        "training_optimization_level": 2
+    }))
+    .unwrap();
     let request = CreateTaskRequest::new()
         .executor(Executor::Builtin)
         .function_id(function_id.clone())
-        .function_arguments(hashmap!(
-            "feature_size"          => "4",
-            "max_depth"             => "4",
-            "iterations"            => "100",
-            "shrinkage"             => "0.1",
-            "feature_sample_ratio"  => "1.0",
-            "data_sample_ratio"     => "1.0",
-            "min_leaf_size"         => "1",
-            "loss"                  => "LAD",
-            "training_optimization_level" => "2"
-        ))
+        .function_arguments(arguments)
         .inputs_ownership(hashmap!("training_data" => vec![USERNAME]))
         .outputs_ownership(hashmap!("trained_model" => vec![USERNAME]));
 

--- a/tests/integration/enclave/src/teaclave_worker.rs
+++ b/tests/integration/enclave/src/teaclave_worker.rs
@@ -17,6 +17,7 @@
 
 use std::prelude::v1::*;
 
+use serde_json::json;
 use teaclave_crypto::TeaclaveFile128Key;
 use teaclave_types::{
     hashmap, read_all_bytes, Executor, ExecutorType, FileAuthTag, FunctionArguments,
@@ -25,17 +26,18 @@ use teaclave_types::{
 use teaclave_worker::Worker;
 
 fn test_start_worker() {
-    let arguments = FunctionArguments::new(hashmap!(
-        "feature_size"  => "4",
-        "max_depth"     => "4",
-        "iterations"    => "100",
-        "shrinkage"     => "0.1",
-        "feature_sample_ratio" => "1.0",
-        "data_sample_ratio" => "1.0",
-        "min_leaf_size" => "1",
-        "loss"          => "LAD",
-        "training_optimization_level" => "2"
-    ));
+    let arguments = FunctionArguments::from_json(json!({
+        "feature_size": 4,
+        "max_depth": 4,
+        "iterations": 100,
+        "shrinkage": 0.1,
+        "feature_sample_ratio": 1.0,
+        "data_sample_ratio": 1.0,
+        "min_leaf_size": 1,
+        "loss": "LAD",
+        "training_optimization_level": 2
+    }))
+    .unwrap();
 
     let plain_input = "fixtures/functions/gbdt_training/train.txt";
     let enc_output = "fixtures/functions/gbdt_training/model.enc.out";


### PR DESCRIPTION
## Description

Use json type (`serde_json::Value`) for function arguments instead of string hashmap (`HashMap<String, String>`).

CI passed: https://ci.mesalock-linux.org/mssun/incubator-mesatee/799