### PR TITLE
[docs] Fix links in docs for website presentation

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -16,15 +16,15 @@ invented our own access control model and mechanism.
 
 ## Model
 The access control model of Teaclave is configured through the file
-[model.conf](../../services/access_control/model.conf).  The file has three
-sections:
+[model.conf](https://github.com/apache/incubator-teaclave/blob/master/services/access_control/model.conf).
+The file has three sections:
   - requests
   - terms
   - matchers
 
 Before diving into the details about how our access control model works, we
-recommend readers learn about [logic
-programming](https://en.wikipedia.org/wiki/Logic_programming) first, because
+recommend readers learn about [logic programming](https://en.wikipedia.org/wiki/Logic_programming)
+first, because
 our model configuration language is actually a home-baked tiny logic
 programming language.
 

--- a/docs/mutual-attestation.md
+++ b/docs/mutual-attestation.md
@@ -44,8 +44,8 @@ before serving any requests.
 
 ## In the Repository 
 
-The [keys/auditors](../keys) directory in the source tree contain the key pairs
-of three fake auditing parties for PoC purposes. Private keys are also included
-to deliver a smooth build and test process. In production, builders of Teaclave
-should obtain the public keys, enclave identities, and the signatures directly
-from the auditors.
+The [keys](https://github.com/apache/incubator-teaclave/tree/master/keys)
+directory in the source tree contain the key pairs of three fake auditing
+parties for PoC purposes. Private keys are also included to deliver a smooth
+build and test process. In production, builders of Teaclave should obtain the
+public keys, enclave identities, and the signatures directly from the auditors.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -48,7 +48,7 @@ the method described by a [white paper](https://arxiv.org/abs/1801.05863). In a
 nutshell, enclaves in Teaclave will establish trusted channel on attested TLS
 for communication. The complicated structure of Teaclave requires additional
 work for remote attestation, which is explained in details via a separate
-[documentation](mutual_attestation.md).
+[documentation](mutual-attestation.md).
 
 Side channels are out of scope for current Teaclave's implementation. While we
 acknowledge that existing enclaves may be vulnerable to various kinds of side

--- a/services/README.md
+++ b/services/README.md
@@ -31,7 +31,7 @@ a safe and secure FaaS platform.
 - **Access Control Service**: Provides a flexible access control domain specific
   language to support access control rules for multi-party secure computation.
   The access control engine is written in Python and evaluated in SGX. Please
-  read [this document](/docs/access-control.md) to learn more about the design of it.
+  read [this document](../docs/access-control.md) to learn more about the design of it.
 - **Scheduler Service**: Schedules staged task ready for execution to a proper
   execution node with desirable capabilities.
 - **Execution Service**: A host of different executors interacting with the
@@ -42,10 +42,12 @@ a safe and secure FaaS platform.
 ## RPC and Protocols
 
 We use ProtoBuf to define messages and RPC interfaces of the Teaclave services.
-You can find detailed protocol definitions in the [`proto` files](./proto/src/proto).
+You can find detailed protocol definitions in the
+[`proto` directory](https://github.com/apache/incubator-teaclave/tree/master/services/proto/src/proto).
 In addition, utility functions, traits, and structures will be automatically
 generated to help implementing services to handle requests and send responses.
-This is done by a build time tool called [`proto_gen`](./proto/proto_gen).
+This is done by a build time tool called
+[`proto_gen`](https://github.com/apache/incubator-teaclave/tree/master/services/proto/proto_gen).
 
 ## Topology
 


### PR DESCRIPTION
## Description

- Fix links in docs for website presentation

Note that when writing docs, if link to GitHub code or directories instead of `.md` files, please use absolute links of GitHub. Otherwise, the generated docs in website will not recognize the internal links to code resulting in broken links.