### PR TITLE
fix a bug that may output incorrect cmac values for small files

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -212,6 +212,7 @@ impl TeaclaveFile128Key {
         use std::io::Write;
         let mut file = ProtectedFile::create_ex(path.as_ref(), &self.key)?;
         file.write_all(content)?;
+        file.flush()?;
         let cmac = file.current_meta_gmac()?;
         Ok(cmac)
     }


### PR DESCRIPTION
## Description

The previous implementation may output incorrect auth_tag values. I tested the current implementation with several files, including an end-to-end example (PSI).

## Type of change (select or add applied and delete the others)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How has this been tested?

## Checklist

- [ ] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the tests pass (see CI results).
- [ ] Make sure your code lints/format.
