### PR TITLE
Only allow info log for release build and triage log levels

### DIFF
--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -24,7 +24,7 @@ cfg-if           = { version = "0.1.9" }
 chrono           = { version = "0.4.6" }
 hex              = { version = "0.4.0" }
 httparse         = { version = "1.3.2", default-features = false }
-log              = { version = "0.4.6" }
+log              = { version = "0.4.6", features = ["release_max_level_info"] }
 num-bigint       = { version = "0.2.2" }
 percent-encoding = { version = "2.1.0" }
 rustls           = { version = "0.16.0", features = ["dangerous_configuration"] }

--- a/binder/Cargo.toml
+++ b/binder/Cargo.toml
@@ -19,7 +19,7 @@ enclave_unit_test = []
 cfg-if     = { version = "0.1.9" }
 anyhow       = { version = "1.0.26" }
 env_logger   = { version = "0.7.1" }
-log          = { version = "0.4.6" }
+log          = { version = "0.4.6", features = ["release_max_level_info"] }
 serde        = { version = "1.0.92", features = ["derive"] }
 serde_json   = { version = "1.0.39" }
 thiserror    = { version = "1.0.9" }

--- a/binder/src/binder.rs
+++ b/binder/src/binder.rs
@@ -18,7 +18,7 @@
 use sgx_types::*;
 use sgx_urts::SgxEnclave;
 
-use log::{debug, info};
+use log::{debug, error};
 use serde::{Deserialize, Serialize};
 
 use crate::ipc::ECallChannel;
@@ -84,7 +84,7 @@ impl TeeBinder {
             FinalizeEnclaveInput,
         ) {
             Ok(_) => {}
-            Err(e) => info!("{:?}", e),
+            Err(e) => error!("{:?}", e),
         }
     }
 }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -13,7 +13,7 @@ build_config = []
 
 [dependencies]
 anyhow = { version = "1.0.26" }
-log    = { version = "0.4.6" }
+log    = { version = "0.4.6", features = ["release_max_level_info"] }
 serde  = { version = "1.0.92", features = ["derive"] }
 toml   = { version = "0.5.1" }
 url    = { version = "2.1.1" }

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -44,7 +44,7 @@ builtin_online_decrypt = []
 builtin_private_join_and_compute = []
 
 [dependencies]
-log           = { version = "0.4.6" }
+log           = { version = "0.4.6", features = ["release_max_level_info"] }
 anyhow        = { version = "1.0.26" }
 serde_json    = { version = "1.0.39" }
 serde         = { version = "1.0.92", features = ["derive"] }

--- a/executor/src/context.rs
+++ b/executor/src/context.rs
@@ -314,7 +314,7 @@ extern "C" fn c_open_input(fid: *mut c_char, out_handle: *mut c_int) -> c_uint {
             FFI_OK
         }
         Err(e) => {
-            info!("c_open_file: {:?}", e);
+            error!("c_open_file: {:?}", e);
             FFI_FILE_ERROR
         }
     }
@@ -337,7 +337,7 @@ extern "C" fn c_create_output(fid: *mut c_char, out_handle: *mut c_int) -> c_uin
             FFI_OK
         }
         Err(e) => {
-            info!("c_open_file: {:?}", e);
+            error!("c_open_file: {:?}", e);
             FFI_FILE_ERROR
         }
     }
@@ -367,7 +367,7 @@ extern "C" fn c_read_file(
             FFI_OK
         }
         Err(e) => {
-            info!("c_read_file: {:?}", e);
+            error!("c_read_file: {:?}", e);
             FFI_FILE_ERROR
         }
     }
@@ -395,7 +395,7 @@ extern "C" fn c_write_file(
             FFI_OK
         }
         Err(e) => {
-            info!("c_write_file: {:?}", e);
+            error!("c_write_file: {:?}", e);
             FFI_FILE_ERROR
         }
     }
@@ -411,7 +411,7 @@ extern "C" fn c_close_file(handle: c_int) -> c_uint {
     match rtc_close_handle(handle) {
         Ok(size) => FFI_OK,
         Err(e) => {
-            info!("c_close_file: {:?}", e);
+            error!("c_close_file: {:?}", e);
             FFI_FILE_ERROR
         }
     }

--- a/file_agent/Cargo.toml
+++ b/file_agent/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["staticlib", "rlib"]
 default = []
 
 [dependencies]
-log           = { version = "0.4.6" }
+log           = { version = "0.4.6", features = ["release_max_level_info"] }
 anyhow        = { version = "1.0.26" }
 serde_json    = { version = "1.0.39" }
 serde         = { version = "1.0.92", features = ["derive"] }

--- a/function/Cargo.toml
+++ b/function/Cargo.toml
@@ -23,7 +23,7 @@ enclave_unit_test = [
 ]
 
 [dependencies]
-log           = { version = "0.4.6" }
+log           = { version = "0.4.6", features = ["release_max_level_info"] }
 anyhow        = { version = "1.0.26" }
 serde_json    = { version = "1.0.39" }
 serde         = { version = "1.0.92", features = ["derive"] }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -18,7 +18,7 @@ mesalock_sgx = [
 anyhow     = { version = "1.0.26" }
 cfg-if     = { version = "0.1.9" }
 http       = { version = "0.2" }
-log        = { version = "0.4.6" }
+log        = { version = "0.4.6", features = ["release_max_level_info"] }
 rustls     = { version = "0.16.0", features = ["dangerous_configuration"] }
 serde      = { version = "1.0.92", features = ["derive"] }
 serde_json = { version = "1.0.39" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -20,7 +20,7 @@ cov = ["sgx_cov"]
 enclave_unit_test = ["teaclave_test_utils/mesalock_sgx"]
 
 [dependencies]
-log           = { version = "0.4.6" }
+log           = { version = "0.4.6", features = ["release_max_level_info"] }
 anyhow        = { version = "1.0.26" }
 teaclave_types = { path = "../types" }
 teaclave_test_utils = { path = "../tests/utils", optional = true }

--- a/services/access_control/enclave/Cargo.toml
+++ b/services/access_control/enclave/Cargo.toml
@@ -29,7 +29,7 @@ enclave_unit_test = ["teaclave_binder/enclave_unit_test", "teaclave_test_utils/m
 [dependencies]
 anyhow    = { version = "1.0.26" }
 cfg-if    = { version = "0.1.9" }
-log       = { version = "0.4.6" }
+log       = { version = "0.4.6", features = ["release_max_level_info"] }
 serde     = { version = "1.0.92" }
 serde_json = { version = "1.0.39" }
 thiserror = { version = "1.0.9" }

--- a/services/authentication/enclave/Cargo.toml
+++ b/services/authentication/enclave/Cargo.toml
@@ -29,7 +29,7 @@ enclave_unit_test = ["teaclave_binder/enclave_unit_test", "teaclave_test_utils/m
 [dependencies]
 anyhow    = { version = "1.0.26" }
 cfg-if    = { version = "0.1.9" }
-log       = { version = "0.4.6" }
+log       = { version = "0.4.6", features = ["release_max_level_info"] }
 serde     = { version = "1.0.92" }
 serde_json = { version = "1.0.39" }
 

--- a/services/authentication/enclave/src/api_service.rs
+++ b/services/authentication/enclave/src/api_service.rs
@@ -157,7 +157,7 @@ pub mod tests {
         let user = service.db_client.get_user("test_login_id").unwrap();
         assert!(user.validate_token(&service.jwt_secret, &token));
 
-        info!("saved user_info: {:?}", user);
+        debug!("saved user_info: {:?}", user);
         let request = UserLoginRequest::new("test_login_id", "test_password1").into_request();
         assert!(service.user_login(request).is_err());
     }

--- a/services/authentication/enclave/src/internal_service.rs
+++ b/services/authentication/enclave/src/internal_service.rs
@@ -96,7 +96,7 @@ pub mod tests {
         let response = get_authenticate_response(id, &token, &service);
         assert!(response.accept);
         let token = validate_token(id, &service.jwt_secret, &token);
-        info!("valid token: {:?}", token.unwrap());
+        debug!("valid token: {:?}", token.unwrap());
     }
 
     pub fn test_invalid_algorithm() {

--- a/services/authentication/enclave/src/user_db.rs
+++ b/services/authentication/enclave/src/user_db.rs
@@ -98,7 +98,7 @@ impl Database {
                 let call: DBCall = match receiver.recv() {
                     Ok(req) => req,
                     Err(e) => {
-                        info!("mspc receive error: {}", e);
+                        warn!("mspc receive error: {}", e);
                         break;
                     }
                 };
@@ -119,7 +119,7 @@ impl Database {
                 };
                 match sender.send(response) {
                     Ok(_) => (),
-                    Err(e) => info!("mpsc send error: {}", e),
+                    Err(e) => warn!("mpsc send error: {}", e),
                 }
             }
         });

--- a/services/execution/enclave/Cargo.toml
+++ b/services/execution/enclave/Cargo.toml
@@ -29,7 +29,7 @@ cov = ["teaclave_service_enclave_utils/cov"]
 enclave_unit_test = ["teaclave_binder/enclave_unit_test", "teaclave_test_utils/mesalock_sgx"]
 
 [dependencies]
-log           = { version = "0.4.6" }
+log           = { version = "0.4.6", features = ["release_max_level_info"] }
 anyhow        = { version = "1.0.26" }
 serde_json    = { version = "1.0.39" }
 serde         = { version = "1.0.92", features = ["derive"] }

--- a/services/execution/enclave/src/service.rs
+++ b/services/execution/enclave/src/service.rs
@@ -75,9 +75,9 @@ impl TeaclaveExecutionService {
                 }
             };
 
-            log::info!("InvokeTask: {:?}", staged_task);
+            log::debug!("InvokeTask: {:?}", staged_task);
             let result = self.invoke_task(&staged_task);
-            log::info!("InvokeTask result: {:?}", result);
+            log::debug!("InvokeTask result: {:?}", result);
 
             match self.update_task_result(&staged_task.task_id, result) {
                 Ok(_) => (),
@@ -114,7 +114,7 @@ impl TeaclaveExecutionService {
         )?;
         let invocation = prepare_task(&task, &file_mgr)?;
 
-        log::info!("Invoke function: {:?}", invocation);
+        log::debug!("Invoke function: {:?}", invocation);
         let worker = Worker::default();
         let summary = worker.invoke_function(invocation)?;
 

--- a/services/execution/enclave/src/task_file_manager.rs
+++ b/services/execution/enclave/src/task_file_manager.rs
@@ -184,7 +184,7 @@ impl InterInputs {
         });
         let request =
             FileAgentRequest::new(HandleFileCommand::Download, req_info, fusion_base.as_ref());
-        log::info!("Ocall file download request: {:?}", request);
+        log::debug!("Ocall file download request: {:?}", request);
         handle_file_request(request)?;
         Ok(())
     }
@@ -285,7 +285,7 @@ impl InterOutputs {
         });
         let request =
             FileAgentRequest::new(HandleFileCommand::Upload, req_info, fusion_base.as_ref());
-        log::info!("Ocall file upload request: {:?}", request);
+        log::debug!("Ocall file upload request: {:?}", request);
         handle_file_request(request)?;
         Ok(())
     }

--- a/services/frontend/enclave/Cargo.toml
+++ b/services/frontend/enclave/Cargo.toml
@@ -29,7 +29,7 @@ enclave_unit_test = ["teaclave_binder/enclave_unit_test", "teaclave_test_utils/m
 [dependencies]
 anyhow    = { version = "1.0.26" }
 cfg-if    = { version = "0.1.9" }
-log       = { version = "0.4.6" }
+log       = { version = "0.4.6", features = ["release_max_level_info"] }
 serde     = { version = "1.0.92" }
 serde_json = { version = "1.0.39" }
 thiserror = { version = "1.0.9" }

--- a/services/management/enclave/Cargo.toml
+++ b/services/management/enclave/Cargo.toml
@@ -29,7 +29,7 @@ enclave_unit_test = ["teaclave_binder/enclave_unit_test", "teaclave_test_utils/m
 [dependencies]
 anyhow    = { version = "1.0.26" }
 cfg-if    = { version = "0.1.9" }
-log       = { version = "0.4.6" }
+log       = { version = "0.4.6", features = ["release_max_level_info"] }
 serde     = { version = "1.0.92" }
 serde_json = { version = "1.0.39" }
 thiserror = { version = "1.0.9" }

--- a/services/management/enclave/src/service.rs
+++ b/services/management/enclave/src/service.rs
@@ -339,7 +339,7 @@ impl TeaclaveManagement for TeaclaveManagementService {
         )
         .map_err(|_| ServiceError::BadTask)?;
 
-        log::info!("CreateTask: {:?}", task);
+        log::debug!("CreateTask: {:?}", task);
 
         let ts: TaskState = task.into();
         self.write_to_db(&ts)
@@ -362,7 +362,7 @@ impl TeaclaveManagement for TeaclaveManagementService {
 
         ensure!(ts.has_participant(&user_id), ServiceError::PermissionDenied);
 
-        log::info!("GetTask: {:?}", ts);
+        log::debug!("GetTask: {:?}", ts);
 
         let response = GetTaskResponse {
             task_id: ts.external_id(),
@@ -427,7 +427,7 @@ impl TeaclaveManagement for TeaclaveManagementService {
                 .map_err(|_| ServiceError::PermissionDenied)?;
         }
 
-        log::info!("AssignData: {:?}", task);
+        log::debug!("AssignData: {:?}", task);
 
         let ts: TaskState = task.into();
         self.write_to_db(&ts)
@@ -458,7 +458,7 @@ impl TeaclaveManagement for TeaclaveManagementService {
         task.approve(&user_id)
             .map_err(|_| ServiceError::PermissionDenied)?;
 
-        log::info!("ApproveTask: approve:{:?}", task);
+        log::debug!("ApproveTask: approve:{:?}", task);
 
         let ts: TaskState = task.into();
         self.write_to_db(&ts)
@@ -488,18 +488,18 @@ impl TeaclaveManagement for TeaclaveManagementService {
             .read_from_db(&ts.function_id)
             .map_err(|_| ServiceError::PermissionDenied)?;
 
-        log::info!("InvokeTask: get function: {:?}", function);
+        log::debug!("InvokeTask: get function: {:?}", function);
 
         let mut task: Task<Stage> = ts.try_into().map_err(|e| {
             log::warn!("Stage state error: {:?}", e);
             ServiceError::PermissionDenied
         })?;
 
-        log::info!("InvokeTask: get task: {:?}", task);
+        log::debug!("InvokeTask: get task: {:?}", task);
 
         let staged_task = task.stage_for_running(&user_id, function)?;
 
-        log::info!("InvokeTask: staged task: {:?}", staged_task);
+        log::debug!("InvokeTask: staged task: {:?}", staged_task);
 
         self.enqueue_to_db(StagedTask::get_queue_key().as_bytes(), &staged_task)?;
 
@@ -658,7 +658,7 @@ pub mod tests {
         assert!(TeaclaveInputFile::match_prefix(&input_file.key_string()));
         let value = input_file.to_vec().unwrap();
         let deserialized_file = TeaclaveInputFile::from_slice(&value).unwrap();
-        info!("file: {:?}", deserialized_file);
+        debug!("file: {:?}", deserialized_file);
     }
 
     pub fn handle_output_file() {
@@ -667,7 +667,7 @@ pub mod tests {
         assert!(TeaclaveOutputFile::match_prefix(&output_file.key_string()));
         let value = output_file.to_vec().unwrap();
         let deserialized_file = TeaclaveOutputFile::from_slice(&value).unwrap();
-        info!("file: {:?}", deserialized_file);
+        debug!("file: {:?}", deserialized_file);
     }
 
     pub fn handle_function() {
@@ -686,7 +686,7 @@ pub mod tests {
         assert!(Function::match_prefix(&function.key_string()));
         let value = function.to_vec().unwrap();
         let deserialized_function = Function::from_slice(&value).unwrap();
-        info!("function: {:?}", deserialized_function);
+        debug!("function: {:?}", deserialized_function);
     }
 
     pub fn handle_task() {
@@ -713,7 +713,7 @@ pub mod tests {
         let ts: TaskState = task.try_into().unwrap();
         let value = ts.to_vec().unwrap();
         let deserialized_task = TaskState::from_slice(&value).unwrap();
-        info!("task: {:?}", deserialized_task);
+        debug!("task: {:?}", deserialized_task);
     }
 
     pub fn handle_staged_task() {
@@ -740,6 +740,6 @@ pub mod tests {
 
         let value = staged_task.to_vec().unwrap();
         let deserialized_data = StagedTask::from_slice(&value).unwrap();
-        info!("staged task: {:?}", deserialized_data);
+        debug!("staged task: {:?}", deserialized_data);
     }
 }

--- a/services/scheduler/enclave/Cargo.toml
+++ b/services/scheduler/enclave/Cargo.toml
@@ -27,7 +27,7 @@ cov = ["teaclave_service_enclave_utils/cov"]
 enclave_unit_test = ["teaclave_binder/enclave_unit_test", "teaclave_test_utils/mesalock_sgx"]
 
 [dependencies]
-log           = { version = "0.4.6" }
+log           = { version = "0.4.6", features = ["release_max_level_info"] }
 anyhow        = { version = "1.0.26" }
 serde_json    = { version = "1.0.39" }
 serde         = { version = "1.0.92", features = ["derive"] }

--- a/services/scheduler/enclave/src/service.rs
+++ b/services/scheduler/enclave/src/service.rs
@@ -170,7 +170,7 @@ impl TeaclaveScheduler for TeaclaveSchedulerService {
         let ts = self.get_task_state(&request.task_id)?;
         let task: Task<Run> = ts.try_into()?;
 
-        log::info!("UpdateTaskStatus: Task {:?}", task);
+        log::debug!("UpdateTaskStatus: Task {:?}", task);
         // Only TaskStatus::Running is implicitly allowed here.
 
         let ts = TaskState::from(task);
@@ -195,7 +195,7 @@ impl TeaclaveScheduler for TeaclaveSchedulerService {
 
         // Updating task result means we have finished execution
         task.update_result(request.task_result)?;
-        log::info!("UpdateTaskResult: Task {:?}", task);
+        log::debug!("UpdateTaskResult: Task {:?}", task);
 
         let ts = TaskState::from(task);
         self.put_into_db(&ts)?;

--- a/services/storage/enclave/Cargo.toml
+++ b/services/storage/enclave/Cargo.toml
@@ -29,7 +29,7 @@ enclave_unit_test = ["teaclave_binder/enclave_unit_test", "teaclave_test_utils/m
 [dependencies]
 anyhow    = { version = "1.0.26" }
 cfg-if    = { version = "0.1.9" }
-log       = { version = "0.4.6" }
+log       = { version = "0.4.6", features = ["release_max_level_info"] }
 serde     = { version = "1.0.92" }
 thiserror = { version = "1.0.9" }
 

--- a/services/utils/service_app_utils/Cargo.toml
+++ b/services/utils/service_app_utils/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 ctrlc      = { version = "3.1.2" }
 env_logger = { version = "0.7.1" }
 anyhow     = { version = "1.0.26" }
-log        = { version = "0.4.6" }
+log        = { version = "0.4.6", features = ["release_max_level_info"] }
 libc        = { version = "0.2.66" }
 signal-hook = { version = "0.1.13" }
 

--- a/services/utils/service_enclave_utils/Cargo.toml
+++ b/services/utils/service_enclave_utils/Cargo.toml
@@ -16,7 +16,7 @@ cov = ["sgx_cov", "sgx_trts"]
 [dependencies]
 anyhow     = { version = "1.0.26" }
 env_logger = { version = "0.7.1" }
-log        = { version = "0.4.6" }
+log        = { version = "0.4.6", features = ["release_max_level_info"] }
 
 teaclave_service_enclave_utils_proc_macro = { path = "./proc_macro" }
 teaclave_types       = { path = "../../../types" }

--- a/tests/functional/app/Cargo.toml
+++ b/tests/functional/app/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 edition = "2018"
 
 [dependencies]
-log        = { version = "0.4.6" }
+log        = { version = "0.4.6", features = ["release_max_level_info"] }
 env_logger = { version = "0.7.1" }
 anyhow     = { version = "1.0.26" }
 structopt  = { version = "0.3" }

--- a/tests/functional/enclave/Cargo.toml
+++ b/tests/functional/enclave/Cargo.toml
@@ -31,7 +31,7 @@ cov = ["teaclave_service_enclave_utils/cov"]
 anyhow      = { version = "1.0.26" }
 inventory   = { version = "0.1.6" }
 lazy_static = { version = "1.4.0" }
-log         = { version = "0.4.6" }
+log         = { version = "0.4.6", features = ["release_max_level_info"] }
 serde       = { version = "1.0.92" }
 serde_json  = { version = "1.0.39" }
 thiserror   = { version = "1.0.9" }

--- a/tests/functional/enclave/src/authentication_service.rs
+++ b/tests/functional/enclave/src/authentication_service.rs
@@ -78,7 +78,7 @@ fn test_login_success() {
 
     let request = UserLoginRequest::new("test_login_id1", "test_password");
     let response_result = client.user_login(request);
-    info!("{:?}", response_result);
+    debug!("{:?}", response_result);
     assert!(response_result.is_ok());
 }
 
@@ -91,7 +91,7 @@ fn test_login_fail() {
 
     let request = UserLoginRequest::new("test_login_id2", "wrong_password");
     let response_result = client.user_login(request);
-    info!("{:?}", response_result);
+    debug!("{:?}", response_result);
     assert!(response_result.is_err());
 }
 
@@ -109,7 +109,7 @@ fn test_authenticate_success() {
     let credential = UserCredential::new("test_authenticate_id1", response_result.unwrap().token);
     let request = UserAuthenticateRequest::new(credential);
     let response_result = internal_client.user_authenticate(request);
-    info!("{:?}", response_result);
+    debug!("{:?}", response_result);
     assert!(response_result.unwrap().accept);
 }
 
@@ -125,7 +125,7 @@ fn test_authenticate_fail() {
     let credential = UserCredential::new("test_authenticate_id2", "wrong_token");
     let request = UserAuthenticateRequest::new(credential);
     let response_result = internal_client.user_authenticate(request);
-    info!("{:?}", response_result);
+    debug!("{:?}", response_result);
     assert!(!response_result.unwrap().accept);
 }
 
@@ -134,7 +134,7 @@ fn test_register_success() {
     let mut client = get_api_client();
     let request = UserRegisterRequest::new("test_register_id1", "test_password");
     let response_result = client.user_register(request);
-    info!("{:?}", response_result);
+    debug!("{:?}", response_result);
     assert!(response_result.is_ok());
 }
 
@@ -146,6 +146,6 @@ fn test_register_fail() {
     assert!(response_result.is_ok());
     let request = UserRegisterRequest::new("test_register_id2", "test_password");
     let response_result = client.user_register(request);
-    info!("{:?}", response_result);
+    debug!("{:?}", response_result);
     assert!(response_result.is_err());
 }

--- a/tests/functional/enclave/src/end_to_end/builtin_echo.rs
+++ b/tests/functional/enclave/src/end_to_end/builtin_echo.rs
@@ -35,7 +35,7 @@ pub fn test_echo_task_success() {
 
     let response = client.register_function(request).unwrap();
 
-    log::info!("Register function: {:?}", response);
+    log::debug!("Register function: {:?}", response);
 
     // Create Task
     let function_id = response.function_id;
@@ -46,7 +46,7 @@ pub fn test_echo_task_success() {
 
     let response = client.create_task(request).unwrap();
 
-    log::info!("Create task: {:?}", response);
+    log::debug!("Create task: {:?}", response);
 
     let task_id = response.task_id;
 

--- a/tests/functional/enclave/src/end_to_end/builtin_gbdt_train.rs
+++ b/tests/functional/enclave/src/end_to_end/builtin_gbdt_train.rs
@@ -69,7 +69,7 @@ fn register_gbdt_function(client: &mut TeaclaveFrontendClient) -> ExternalID {
         .outputs(vec![fn_output]);
 
     let response = client.register_function(request).unwrap();
-    log::info!("Register function: {:?}", response);
+    log::debug!("Register function: {:?}", response);
     response.function_id
 }
 
@@ -82,7 +82,7 @@ fn register_input_file(client: &mut TeaclaveFrontendClient) -> ExternalID {
 
     let request = RegisterInputFileRequest::new(url, cmac, crypto_info);
     let response = client.register_input_file(request).unwrap();
-    log::info!("Register input: {:?}", response);
+    log::debug!("Register input: {:?}", response);
     response.data_id
 }
 
@@ -95,7 +95,7 @@ fn register_output_file(
             .unwrap();
     let request = RegisterOutputFileRequest::new(url, crypto);
     let response = client.register_output_file(request).unwrap();
-    log::info!("Register output: {:?}", response);
+    log::debug!("Register output: {:?}", response);
     response.data_id
 }
 
@@ -123,7 +123,7 @@ fn create_gbdt_training_task(
         .outputs_ownership(hashmap!("trained_model" => vec![USERNAME]));
 
     let response = client.create_task(request).unwrap();
-    log::info!("Create task: {:?}", response);
+    log::debug!("Create task: {:?}", response);
 
     response.task_id
 }
@@ -142,5 +142,5 @@ fn assign_data_to_task(
     );
     let response = client.assign_data(request).unwrap();
 
-    log::info!("Assign data: {:?}", response);
+    log::debug!("Assign data: {:?}", response);
 }

--- a/tests/functional/enclave/src/end_to_end/mesapy_data_fusion.rs
+++ b/tests/functional/enclave/src/end_to_end/mesapy_data_fusion.rs
@@ -64,7 +64,7 @@ def entrypoint(argv):
         .inputs(vec![input1, input2])
         .outputs(vec![fusion_output]);
     let response = client.register_function(request).unwrap();
-    log::info!("Resgister function: {:?}", response);
+    log::debug!("Resgister function: {:?}", response);
     response.function_id
 }
 
@@ -78,7 +78,7 @@ fn register_input_file(
     let cmac = FileAuthTag::from_hex(auth_tag.as_ref()).unwrap();
     let request = RegisterInputFileRequest::new(url, cmac, crypto);
     let response = client.register_input_file(request).unwrap();
-    log::info!("Register input: {:?}", response);
+    log::debug!("Register input: {:?}", response);
     response.data_id
 }
 
@@ -104,7 +104,7 @@ fn create_data_fusion_task(
         .outputs_ownership(hashmap!("OutFusionData" => vec![USERNAME1, USERNAME2]))
         .executor(Executor::MesaPy);
     let response = client.create_task(request).unwrap();
-    log::info!("Create task: {:?}", response);
+    log::debug!("Create task: {:?}", response);
     response.task_id
 }
 
@@ -116,7 +116,7 @@ fn assign_data_for_task(
 ) {
     let request = AssignDataRequest::new(task_id.clone(), input_map, output_map);
     let response = client.assign_data(request).unwrap();
-    log::info!("Assign data: {:?}", response);
+    log::debug!("Assign data: {:?}", response);
 }
 
 #[test_case]
@@ -239,7 +239,7 @@ def entrypoint(argv):
         .public(true)
         .inputs(vec![input_spec]);
     let response = client.register_function(request).unwrap();
-    log::info!("Resgister function: {:?}", response);
+    log::debug!("Resgister function: {:?}", response);
     response.function_id
 }
 
@@ -256,6 +256,6 @@ fn create_wlc_task(
         ))
         .executor(Executor::MesaPy);
     let response = client.create_task(request).unwrap();
-    log::info!("Create task: {:?}", response);
+    log::debug!("Create task: {:?}", response);
     response.task_id
 }

--- a/tests/functional/enclave/src/end_to_end/mesapy_echo.rs
+++ b/tests/functional/enclave/src/end_to_end/mesapy_echo.rs
@@ -44,7 +44,7 @@ def entrypoint(argv):
 
     let response = client.register_function(request).unwrap();
 
-    log::info!("Resgister function: {:?}", response);
+    log::debug!("Resgister function: {:?}", response);
 
     // Create Task
     let function_id = response.function_id;
@@ -55,14 +55,14 @@ def entrypoint(argv):
 
     let response = client.create_task(request).unwrap();
 
-    log::info!("Create task: {:?}", response);
+    log::debug!("Create task: {:?}", response);
 
     // Assign Data To Task
     let task_id = response.task_id;
     let request = AssignDataRequest::new(task_id.clone(), hashmap!(), hashmap!());
     let response = client.assign_data(request).unwrap();
 
-    log::info!("Assign data: {:?}", response);
+    log::debug!("Assign data: {:?}", response);
 
     // Approve Task
     approve_task(&mut client, &task_id).unwrap();

--- a/tests/functional/enclave/src/end_to_end/mod.rs
+++ b/tests/functional/enclave/src/end_to_end/mod.rs
@@ -29,7 +29,7 @@ mod mesapy_echo;
 fn get_task(client: &mut TeaclaveFrontendClient, task_id: &ExternalID) -> GetTaskResponse {
     let request = GetTaskRequest::new(task_id.clone());
     let response = client.get_task(request).unwrap();
-    log::info!("Get task: {:?}", response);
+    log::debug!("Get task: {:?}", response);
     response
 }
 
@@ -41,7 +41,7 @@ fn get_task_until(
     loop {
         let request = GetTaskRequest::new(task_id.clone());
         let response = client.get_task(request).unwrap();
-        log::info!("Get task: {:?}", response);
+        log::debug!("Get task: {:?}", response);
 
         std::thread::sleep(std::time::Duration::from_secs(1));
 
@@ -49,7 +49,7 @@ fn get_task_until(
             match response.result {
                 TaskResult::Ok(outputs) => {
                     let ret_val = String::from_utf8(outputs.return_value).unwrap();
-                    log::info!("Task returns: {:?}", ret_val);
+                    log::debug!("Task returns: {:?}", ret_val);
                     return ret_val;
                 }
                 TaskResult::Err(failure) => {
@@ -65,13 +65,13 @@ fn get_task_until(
 fn approve_task(client: &mut TeaclaveFrontendClient, task_id: &ExternalID) -> anyhow::Result<()> {
     let request = ApproveTaskRequest::new(task_id.clone());
     let response = client.approve_task(request)?;
-    log::info!("Approve task: {:?}", response);
+    log::debug!("Approve task: {:?}", response);
     Ok(())
 }
 
 fn invoke_task(client: &mut TeaclaveFrontendClient, task_id: &ExternalID) -> anyhow::Result<()> {
     let request = InvokeTaskRequest::new(task_id.clone());
     let response = client.invoke_task(request)?;
-    log::info!("Invoke task: {:?}", response);
+    log::debug!("Invoke task: {:?}", response);
     Ok(())
 }

--- a/tests/functional/enclave/src/storage_service.rs
+++ b/tests/functional/enclave/src/storage_service.rs
@@ -34,7 +34,7 @@ fn test_get_success() {
     let mut client = get_client();
     let request = GetRequest::new("test_get_key");
     let response_result = client.get(request);
-    info!("{:?}", response_result);
+    debug!("{:?}", response_result);
     assert!(response_result.is_ok());
 }
 
@@ -51,12 +51,12 @@ fn test_put_success() {
     let mut client = get_client();
     let request = PutRequest::new("test_put_key", "test_put_value");
     let response_result = client.put(request);
-    info!("{:?}", response_result);
+    debug!("{:?}", response_result);
     assert!(response_result.is_ok());
 
     let request = GetRequest::new("test_put_key");
     let response_result = client.get(request);
-    info!("{:?}", response_result);
+    debug!("{:?}", response_result);
     assert!(response_result.is_ok());
     assert_eq!(response_result.unwrap().value, b"test_put_value");
 }
@@ -66,7 +66,7 @@ fn test_delete_success() {
     let mut client = get_client();
     let request = DeleteRequest::new("test_delete_key");
     let response_result = client.delete(request);
-    info!("{:?}", response_result);
+    debug!("{:?}", response_result);
     assert!(response_result.is_ok());
 
     let request = GetRequest::new("test_delete_key");
@@ -79,7 +79,7 @@ fn test_enqueue_success() {
     let mut client = get_client();
     let request = EnqueueRequest::new("test_enqueue_key", "test_enqueue_value");
     let response_result = client.enqueue(request);
-    info!("{:?}", response_result);
+    debug!("{:?}", response_result);
     assert!(response_result.is_ok());
 }
 

--- a/tests/functional/enclave/src/utils.rs
+++ b/tests/functional/enclave/src/utils.rs
@@ -141,7 +141,7 @@ pub fn register_new_account(
     let request = UserRegisterRequest::new(username, password);
     let response = api_client.user_register(request)?;
 
-    log::info!("User register: {:?}", response);
+    log::debug!("User register: {:?}", response);
 
     Ok(())
 }
@@ -154,7 +154,7 @@ pub fn login(
     let request = UserLoginRequest::new(username, password);
     let response = api_client.user_login(request)?;
 
-    log::info!("User login: {:?}", response);
+    log::debug!("User login: {:?}", response);
 
     Ok(UserCredential::new(username, response.token))
 }

--- a/tests/integration/app/Cargo.toml
+++ b/tests/integration/app/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 edition = "2018"
 
 [dependencies]
-log        = { version = "0.4.6" }
+log        = { version = "0.4.6", features = ["release_max_level_info"] }
 env_logger = { version = "0.7.1" }
 anyhow     = { version = "1.0.26" }
 

--- a/tests/integration/enclave/Cargo.toml
+++ b/tests/integration/enclave/Cargo.toml
@@ -30,7 +30,7 @@ mesalock_sgx = [
 cov = ["teaclave_service_enclave_utils/cov"]
 
 [dependencies]
-log         = { version = "0.4.6" }
+log         = { version = "0.4.6", features = ["release_max_level_info"] }
 anyhow      = { version = "1.0.26" }
 serde       = { version = "1.0.92" }
 serde_json  = { version = "1.0.39" }

--- a/tests/integration/enclave/src/teaclave_rpc.rs
+++ b/tests/integration/enclave/src/teaclave_rpc.rs
@@ -62,7 +62,7 @@ impl TeaclaveService<EchoRequest, EchoResponse> for EchoService {
         &self,
         request: teaclave_rpc::Request<EchoRequest>,
     ) -> TeaclaveServiceResponseResult<EchoResponse> {
-        info!("handle request: {:?}", request);
+        debug!("handle request: {:?}", request);
         let message = match request.message {
             EchoRequest::Say(s) => s.message,
         };
@@ -138,7 +138,7 @@ fn echo_success() {
         message: "Hello, World!".to_string(),
     };
     let response_result = client.say(request);
-    info!("{:?}", response_result);
+    debug!("{:?}", response_result);
 
     assert!(response_result.is_ok());
     assert!(response_result.unwrap().message == "Hello, World!");

--- a/tests/unit/app/Cargo.toml
+++ b/tests/unit/app/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 edition = "2018"
 
 [dependencies]
-log        = { version = "0.4.6" }
+log        = { version = "0.4.6", features = ["release_max_level_info"] }
 env_logger = { version = "0.7.1" }
 anyhow     = { version = "1.0.26" }
 

--- a/tests/unit/enclave/Cargo.toml
+++ b/tests/unit/enclave/Cargo.toml
@@ -50,7 +50,7 @@ mesalock_sgx = [
 cov = ["teaclave_service_enclave_utils/cov"]
 
 [dependencies]
-log         = { version = "0.4.6" }
+log         = { version = "0.4.6", features = ["release_max_level_info"] }
 anyhow      = { version = "1.0.26" }
 serde       = { version = "1.0.92" }
 thiserror   = { version = "1.0.9" }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -20,7 +20,7 @@ enclave_unit_test = ["teaclave_test_utils/mesalock_sgx"]
 [dependencies]
 protected_fs_rs  = { path = "../common/protected_fs_rs", default-features = false}
 
-log           = { version = "0.4.6" }
+log           = { version = "0.4.6", features = ["release_max_level_info"] }
 anyhow       = { version = "1.0.26" }
 sgx_types    = { version = "1.1.2" }
 rand         = { version = "0.7.0" }

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -22,7 +22,7 @@ cov = ["sgx_cov"]
 enclave_unit_test = ["teaclave_test_utils/mesalock_sgx"]
 
 [dependencies]
-log           = { version = "0.4.6" }
+log           = { version = "0.4.6", features = ["release_max_level_info"] }
 anyhow        = { version = "1.0.26" }
 serde_json    = { version = "1.0.39" }
 thiserror     = { version = "1.0.9" }


### PR DESCRIPTION
## Description

 - Only allow info log for release build and triage log levels

Note that this feature can control a compile time filter (https://docs.rs/log/0.4.8/log/#compile-time-filters).

Also, for log levels, I found that most `info!` are `debug!` and some are `error!`. Please don't misuse the log level.