### PR TITLE
[cli] Add verify subcommand to verify enclave info signatures

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,3 +11,5 @@ anyhow = { version = "1.0.26" }
 structopt = "0.3"
 teaclave_crypto = { path = "../crypto" }
 hex = { version = "0.4.0" }
+teaclave_types = { path = "../types" }
+pem = "0.7.0"

--- a/cli/README.md
+++ b/cli/README.md
@@ -5,8 +5,12 @@ permalink: /cli
 # Teaclave Command Line Tool
 
 The Teaclave command line tool (`teaclave_cli`) provides utilities to
-interactive with the platform. The command line tool has several subcommands:
+interactive with the platform. The command line tool has several sub-commands:
 
-- encrypt/decrypt: These two subcommands are to encrypt/decrypt data used on the
-  platform. Supported algorithms include AES-GCM (128bit and 256 bit), and
+- `encrypt`/`decrypt`: These two subcommands are to encrypt/decrypt data used on
+  the platform. Supported algorithms include AES-GCM (128bit and 256 bit), and
   Teaclave File (128bit).
+- `verify`: Verify the signatures of the enclave info (which contains `MRSIGNER`
+  and `MRENCLAVE`) signed by auditors with their public keys. The enclave info
+  is used for remote attestation, Please verify it before connecting the
+  platform with the client SDK.

--- a/cmake/scripts/test.sh
+++ b/cmake/scripts/test.sh
@@ -138,6 +138,12 @@ run_examples() {
 
   echo_title "examples"
   mkdir -p /tmp/fusion_data
+  pushd ${TEACLAVE_CLI_INSTALL_DIR}
+  ./teaclave_cli verify \
+                 --enclave-info ../examples/enclave_info.toml \
+                 --public-keys $(find ../examples -name "*.public.pem") \
+                 --signatures $(find ../examples -name "*.sign.sha256")
+  popd
   pushd ${TEACLAVE_SERVICE_INSTALL_DIR}
   ./teaclave_authentication_service &
   ./teaclave_storage_service &

--- a/examples/python/utils.py
+++ b/examples/python/utils.py
@@ -19,4 +19,4 @@ if os.environ.get('TEACLAVE_PROJECT_ROOT'):
         "/release/tests/enclave_info.toml"
 else:
     AS_ROOT_CA_CERT_PATH = "../../keys/" + AS_ROOT_CERT_FILENAME
-    ENCLAVE_INFO_PATH = "../../release/tests/enclave_info.toml"
+    ENCLAVE_INFO_PATH = "../../release/examples/enclave_info.toml"


### PR DESCRIPTION
## Description

- Add a sub-command for clients to verify signatures before using the enclave info to connect the platform.