### PR TITLE
Add the make doc target to generate docs of crates in Teaclave

### DIFF
--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -13,6 +13,8 @@ mesalock_sgx = [
     "sgx_tcrypto",
     "sgx_rand",
     "sgx_tse",
+    "teaclave_types/mesalock_sgx",
+    "teaclave_config/mesalock_sgx",
 ]
 enclave_unit_test = ["teaclave_test_utils/mesalock_sgx"]
 
@@ -39,7 +41,7 @@ yasna            = { version = "0.3.0", features = ["bit-vec", "num-bigint", "ch
 
 teaclave_types  = { path = "../types" }
 teaclave_config = { path = "../config", features = ["build_config"] }
-teaclave_test_utils = { path = "../tests/utils" }
+teaclave_test_utils = { path = "../tests/utils", optional = true }
 
 sgx_rand    = { version = "1.1.2", optional = true }
 sgx_tcrypto = { version = "1.1.2", optional = true }

--- a/binder/Cargo.toml
+++ b/binder/Cargo.toml
@@ -11,7 +11,9 @@ default = []
 app = ["sgx_urts"]
 mesalock_sgx = [
     "sgx_tstd",
-    "teaclave_binder_attribute"
+    "teaclave_binder_attribute",
+    "teaclave_types/mesalock_sgx",
+    "teaclave_config/mesalock_sgx",
 ]
 enclave_unit_test = []
 

--- a/cmake/UtilTargets.cmake
+++ b/cmake/UtilTargets.cmake
@@ -86,10 +86,11 @@ set_property(
 add_custom_target(
   doc
   COMMAND
-    cd ${PROJECT_BINARY_DIR}/cmake_tomls/unix_app && ${TEACLAVE_COMMON_ENVS}
-    cargo doc --all ${CARGO_BUILD_FLAGS} ${MTEE_EXTRA_CARGO_FLAGS} && cp -RT
-    ${PROJECT_BINARY_DIR}/cmake_tomls/unix_app/target/doc
-    ${TEACLAVE_DOC_INSTALL_DIR}
+    make DOC=1 all
+    && mkdir -p ${TEACLAVE_DOC_INSTALL_DIR}
+    && cp -RT ${TEACLAVE_TARGET_DIR}/trusted/doc ${TEACLAVE_DOC_INSTALL_DIR}/enclave
+    && cp -RT ${TEACLAVE_TARGET_DIR}/untrusted/doc ${TEACLAVE_DOC_INSTALL_DIR}/app
+    && cp -RT ${TEACLAVE_TARGET_DIR}/unix/doc ${TEACLAVE_DOC_INSTALL_DIR}/unix
   DEPENDS prep)
 
 # clippy target

--- a/cmake/scripts/cargo_build_ex.sh
+++ b/cmake/scripts/cargo_build_ex.sh
@@ -15,3 +15,8 @@ fi
 if [ ! -z "$CLP" ]; then
     cargo clippy "$@" -- -D warnings
 fi
+
+# if DOC is set, run cargo doc after cargo build
+if [ ! -z "$DOC" ]; then
+    RUSTDOCFLAGS="--enable-index-page -Zunstable-options" RUSTC="${RUSTC}" cargo doc "$@"
+fi

--- a/common/protected_fs_rs/Cargo.toml
+++ b/common/protected_fs_rs/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 name = "protected_fs"
 
 [features]
-default = ["libc"]
+default = []
 mesalock_sgx = ["sgx_tstd", "sgx_types", "sgx_trts"]
 
 [dependencies]
@@ -18,7 +18,7 @@ cfg-if      = { version = "0.1.9" }
 rdrand      = { version = "0.6", default-features = false }
 rand_core   = { version = "0.4", default-features = false }
 
-libc        = { version = "0.2", optional = true }
+libc        = { version = "0.2" }
 
 sgx_types = { version = "1.1.2", optional = true }
 sgx_tstd = { version = "1.1.2",  optional = true }

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -62,6 +62,7 @@ To set a variable or option, you can pass `-DXXX=` to `cmake`. For example,
   ON.
 - `CLP`: Enable `cargo clippy` to lint Rust code during the compilation.
   Defaults to OFF.
+- `DOC`: Generate document with `cargo doc` during the compilation. Defaults to OFF.
 
 ## Targets
 
@@ -102,6 +103,11 @@ Above targets are automatically generated from the
 ### Linting
 
 - `format`: Format all code.
+- `clippy`: Run `cargo clippy` for linting. Same with `make CLP=1`.
+
+### Doc
+
+- `doc`: Run `cargo doc` to generate documents. Same with `make DOC=1`.
 
 ### Tests
 

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -15,6 +15,8 @@ default = []
 mesalock_sgx = [
   "sgx_tstd",
   "teaclave_types/mesalock_sgx",
+  "teaclave_crypto/mesalock_sgx",
+  "teaclave_runtime/mesalock_sgx",
   "teaclave_function/mesalock_sgx",
 ]
 cov = ["sgx_cov"]
@@ -56,11 +58,12 @@ thiserror     = { version = "1.0.9" }
 gbdt          = { version = "0.1.0", features = ["input", "enable_training"] }
 rusty-machine = { version = "0.5.4" }
 itertools     = { version = "0.8.0", default-features = false }
-teaclave_types = { path = "../types" }
-teaclave_crypto = { path = "../crypto" }
-teaclave_runtime = { path = "../runtime", optional = true }
+
+teaclave_types      = { path = "../types" }
+teaclave_crypto     = { path = "../crypto" }
+teaclave_runtime    = { path = "../runtime", optional = true }
 teaclave_test_utils = { path = "../tests/utils", optional = true }
-teaclave_function = { path = "../function" }
+teaclave_function   = { path = "../function" }
 
 sgx_cov       = { version = "1.1.2", optional = true }
 sgx_tstd      = { version = "1.1.2", features = ["net", "thread", "backtrace"], optional = true }

--- a/file_agent/Cargo.toml
+++ b/file_agent/Cargo.toml
@@ -20,6 +20,7 @@ serde_json    = { version = "1.0.39" }
 serde         = { version = "1.0.92", features = ["derive"] }
 thiserror     = { version = "1.0.9" }
 itertools     = { version = "0.8.0", default-features = false }
+
 teaclave_types = { path = "../types" }
 teaclave_test_utils = { path = "../tests/utils", optional = true }
 

--- a/function/Cargo.toml
+++ b/function/Cargo.toml
@@ -15,6 +15,8 @@ default = []
 mesalock_sgx = [
   "sgx_tstd",
   "teaclave_types/mesalock_sgx",
+  "teaclave_crypto/mesalock_sgx",
+  "teaclave_runtime/mesalock_sgx",
 ]
 cov = ["sgx_cov"]
 enclave_unit_test = [
@@ -34,6 +36,7 @@ itertools     = { version = "0.8.0", default-features = false }
 ring          = { version = "0.16.5" }
 base64        = { version = "0.10.1" }
 hex           = { version = "0.4.0"  }
+
 teaclave_types = { path = "../types" }
 teaclave_crypto = { path = "../crypto" }
 teaclave_runtime = { path = "../runtime", optional = true }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -12,6 +12,7 @@ mesalock_sgx = [
     "sgx_trts",
     "sgx_tstd",
     "teaclave_types/mesalock_sgx",
+    "teaclave_attestation/mesalock_sgx",
 ]
 
 [dependencies]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,6 +22,7 @@ enclave_unit_test = ["teaclave_test_utils/mesalock_sgx"]
 [dependencies]
 log           = { version = "0.4.6", features = ["release_max_level_info"] }
 anyhow        = { version = "1.0.26" }
+
 teaclave_types = { path = "../types" }
 teaclave_test_utils = { path = "../tests/utils", optional = true }
 

--- a/services/access_control/enclave/Cargo.toml
+++ b/services/access_control/enclave/Cargo.toml
@@ -27,14 +27,14 @@ cov = ["teaclave_service_enclave_utils/cov"]
 enclave_unit_test = ["teaclave_binder/enclave_unit_test", "teaclave_test_utils/mesalock_sgx"]
 
 [dependencies]
-anyhow    = { version = "1.0.26" }
-cfg-if    = { version = "0.1.9" }
-log       = { version = "0.4.6", features = ["release_max_level_info"] }
-serde     = { version = "1.0.92" }
+anyhow     = { version = "1.0.26" }
+cfg-if     = { version = "0.1.9" }
+log        = { version = "0.4.6", features = ["release_max_level_info"] }
+serde      = { version = "1.0.92" }
 serde_json = { version = "1.0.39" }
-thiserror = { version = "1.0.9" }
-ring      = { version = "0.16.5" }
-rand      = { version = "0.7.0" }
+thiserror  = { version = "1.0.9" }
+ring       = { version = "0.16.5" }
+rand       = { version = "0.7.0" }
 
 teaclave_attestation           = { path = "../../../attestation" }
 teaclave_config                = { path = "../../../config" }
@@ -43,7 +43,7 @@ teaclave_binder                = { path = "../../../binder" }
 teaclave_rpc                   = { path = "../../../rpc" }
 teaclave_service_enclave_utils = { path = "../../utils/service_enclave_utils" }
 teaclave_types                 = { path = "../../../types" }
-teaclave_test_utils            = { path = "../../../tests/utils" }
+teaclave_test_utils            = { path = "../../../tests/utils", optional = true }
 
 sgx_tstd      = { version = "1.1.2", features = ["net", "thread", "backtrace"], optional = true }
 sgx_types     = { version = "1.1.2" }

--- a/services/execution/enclave/Cargo.toml
+++ b/services/execution/enclave/Cargo.toml
@@ -47,7 +47,7 @@ teaclave_service_enclave_utils = { path = "../../utils/service_enclave_utils" }
 teaclave_types                 = { path = "../../../types" }
 teaclave_crypto                = { path = "../../../crypto" }
 teaclave_worker                = { path = "../../../worker" }
-teaclave_test_utils            = { path = "../../../tests/utils", optional = true }
+teaclave_test_utils            = { path = "../../../tests/utils" , optional = true }
 
 sgx_cov       = { version = "1.1.2", optional = true }
 sgx_tstd      = { version = "1.1.2", features = ["net", "thread", "backtrace"], optional = true }

--- a/services/frontend/enclave/Cargo.toml
+++ b/services/frontend/enclave/Cargo.toml
@@ -43,7 +43,7 @@ teaclave_binder                = { path = "../../../binder" }
 teaclave_rpc                   = { path = "../../../rpc" }
 teaclave_service_enclave_utils = { path = "../../utils/service_enclave_utils" }
 teaclave_types                 = { path = "../../../types" }
-teaclave_test_utils            = { path = "../../../tests/utils" }
+teaclave_test_utils            = { path = "../../../tests/utils", optional = true }
 
 sgx_tstd      = { version = "1.1.2", features = ["net", "thread", "backtrace"], optional = true }
 sgx_types     = { version = "1.1.2" }

--- a/services/management/enclave/Cargo.toml
+++ b/services/management/enclave/Cargo.toml
@@ -45,7 +45,7 @@ teaclave_binder                = { path = "../../../binder" }
 teaclave_rpc                   = { path = "../../../rpc" }
 teaclave_service_enclave_utils = { path = "../../utils/service_enclave_utils" }
 teaclave_types                 = { path = "../../../types" }
-teaclave_test_utils            = { path = "../../../tests/utils" }
+teaclave_test_utils            = { path = "../../../tests/utils", optional = true }
 
 sgx_tstd      = { version = "1.1.2", features = ["net", "thread", "backtrace"], optional = true }
 sgx_types     = { version = "1.1.2" }

--- a/services/proto/Cargo.toml
+++ b/services/proto/Cargo.toml
@@ -11,6 +11,7 @@ default = []
 mesalock_sgx = [
     "sgx_tstd",
     "teaclave_types/mesalock_sgx",
+    "teaclave_rpc/mesalock_sgx",
     "teaclave_crypto/mesalock_sgx",
 ]
 cov = ["sgx_cov"]
@@ -29,6 +30,7 @@ uuid          = { version = "0.8.1", features = ["v4"] }
 sgx_cov      = { version = "1.1.2", optional = true }
 sgx_tstd     = { version = "1.1.2", features = ["net", "backtrace"], optional = true }
 sgx_types    = { version = "1.1.2" }
+
 teaclave_rpc = { path = "../../rpc" }
 teaclave_types = { path = "../../types" }
 teaclave_crypto = { path = "../../crypto" }

--- a/services/utils/service_enclave_utils/Cargo.toml
+++ b/services/utils/service_enclave_utils/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2018"
 default = []
 mesalock_sgx = [
     "sgx_tstd",
+    "teaclave_types/mesalock_sgx",
+    "teaclave_attestation/mesalock_sgx",
+    "teaclave_rpc/mesalock_sgx",
 ]
 cov = ["sgx_cov", "sgx_trts"]
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -18,8 +18,6 @@ mesalock_sgx = [
 enclave_unit_test = ["teaclave_test_utils/mesalock_sgx"]
 
 [dependencies]
-protected_fs_rs  = { path = "../common/protected_fs_rs", default-features = false}
-
 log           = { version = "0.4.6", features = ["release_max_level_info"] }
 anyhow       = { version = "1.0.26" }
 sgx_types    = { version = "1.1.2" }
@@ -33,6 +31,7 @@ thiserror    = { version = "1.0.9" }
 url          = { version = "2.1.1", features = ["serde"]}
 uuid         = { version = "0.8.1", features = ["v4", "serde"] }
 
+protected_fs_rs  = { path = "../common/protected_fs_rs" }
 teaclave_test_utils = { path = "../tests/utils", optional = true }
 teaclave_crypto = { path = "../crypto" }
 

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -26,6 +26,7 @@ log           = { version = "0.4.6", features = ["release_max_level_info"] }
 anyhow        = { version = "1.0.26" }
 serde_json    = { version = "1.0.39" }
 thiserror     = { version = "1.0.9" }
+
 teaclave_types = { path = "../types" }
 teaclave_executor = { path = "../executor", features = ["full_builtin_function"] }
 teaclave_runtime = { path = "../runtime" }


### PR DESCRIPTION
## Description

 - Add the `make doc` target to generate docs of crates in Teaclave.
 - To support it, some dependencies are fixed in `Cargo.toml` (features and optional).
  - Document this in the build system doc.

CI passed: https://ci.mesalock-linux.org/mssun/incubator-mesatee/946