### PR TITLE
fix downloading large remote input file bug

### DIFF
--- a/file_agent/src/agent.rs
+++ b/file_agent/src/agent.rs
@@ -35,7 +35,7 @@ async fn download_remote_input_to_file(
     let mut outfile = tokio::fs::File::create(dest).await?;
 
     while let Some(chunk) = download.chunk().await? {
-        outfile.write(&chunk).await?;
+        outfile.write_all(&chunk).await?;
     }
 
     // Must flush tokio::io::BufWriter manually.


### PR DESCRIPTION
## Description

Change write method to write_all, in order to fix downloading large remote input file bug.

According to [tokio doc](https://docs.rs/tokio/0.1.22/tokio/prelude/trait.Write.html), method write cannot guarantee writing the whole buffer, but method write_all will continuously call write until there is no more data to be written or an error of non-ErrorKind::Interrupted kind is returned. 

