### PR TITLE
Increase heap size of enclave

### DIFF
--- a/docker/docker-compose-ubuntu-1804.yml
+++ b/docker/docker-compose-ubuntu-1804.yml
@@ -23,7 +23,7 @@ services:
       - AS_KEY
       - AS_ALGO
       - AS_URL
-      - RUST_LOG
+      - TEACLAVE_LOG
     entrypoint: ./teaclave_authentication_service
     container_name: teaclave-authentication-service
     networks:
@@ -51,7 +51,7 @@ services:
       - AS_KEY
       - AS_ALGO
       - AS_URL
-      - RUST_LOG
+      - TEACLAVE_LOG
     entrypoint: ./teaclave_frontend_service
     depends_on:
       - teaclave-management-service
@@ -79,7 +79,7 @@ services:
       - AS_KEY
       - AS_ALGO
       - AS_URL
-      - RUST_LOG
+      - TEACLAVE_LOG
     entrypoint: ./teaclave_management_service
     depends_on:
       - teaclave-storage-service
@@ -107,7 +107,7 @@ services:
       - AS_KEY
       - AS_ALGO
       - AS_URL
-      - RUST_LOG
+      - TEACLAVE_LOG
     entrypoint: ./teaclave_storage_service
     container_name: teaclave-storage-service
     networks:
@@ -132,7 +132,7 @@ services:
       - AS_KEY
       - AS_ALGO
       - AS_URL
-      - RUST_LOG
+      - TEACLAVE_LOG
     container_name: teaclave-access-control-service
     entrypoint: ./teaclave_access_control_service
     networks:
@@ -157,7 +157,7 @@ services:
       - AS_KEY
       - AS_ALGO
       - AS_URL
-      - RUST_LOG
+      - TEACLAVE_LOG
     entrypoint: ./teaclave_execution_service
     container_name: teaclave-execution-service
     depends_on:
@@ -184,7 +184,7 @@ services:
       - AS_KEY
       - AS_ALGO
       - AS_URL
-      - RUST_LOG
+      - TEACLAVE_LOG
     entrypoint: ./teaclave_scheduler_service
     container_name: teaclave-scheduler-service
     depends_on:

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use log::debug;
+use log::trace;
 use serde::{Deserialize, Serialize};
 use std::io;
 use std::prelude::v1::*;
@@ -64,8 +64,8 @@ where
     pub fn new(transport: &'a mut T) -> JsonProtocol<'a, T> {
         Self {
             transport,
-            // Default max frame length is 8MB
-            max_frame_len: 8 * 1_024 * 1_024,
+            // Default max frame length is 32MB
+            max_frame_len: 32 * 1_024 * 1_024,
         }
     }
 
@@ -86,7 +86,7 @@ where
         let mut recv_buf: Vec<u8> = vec![0u8; buf_len as usize];
         self.transport.read_exact(&mut recv_buf)?;
 
-        debug!("Recv: {}", std::string::String::from_utf8_lossy(&recv_buf));
+        trace!("Recv: {}", std::string::String::from_utf8_lossy(&recv_buf));
         let r: V = serde_json::from_slice(&recv_buf)?;
 
         Ok(r)
@@ -98,7 +98,7 @@ where
     {
         let send_buf = serde_json::to_vec(&message)?;
 
-        debug!("Send: {}", std::string::String::from_utf8_lossy(&send_buf));
+        trace!("Send: {}", std::string::String::from_utf8_lossy(&send_buf));
 
         let buf_len = send_buf.len() as u64;
         let header = buf_len.to_be_bytes();

--- a/sdk/python/teaclave.py
+++ b/sdk/python/teaclave.py
@@ -434,14 +434,19 @@ def _write_message(sock: ssl.SSLSocket, message: Any):
             return o.__dict__
 
     message = json.dumps(message, cls=RequestEncoder).encode()
-    sock.write(struct.pack(">Q", len(message)))
-    sock.write(message)
+    sock.sendall(struct.pack(">Q", len(message)))
+    sock.sendall(message)
 
 
 def _read_message(sock: ssl.SSLSocket):
     response_len = struct.unpack(">Q", sock.read(8))
-    response = sock.read(response_len[0])
-    response = json.loads(response)
+    raw = bytearray()
+    total_recv = 0
+    while total_recv < response_len[0]:
+        data = sock.recv()
+        total_recv += len(data)
+        raw += data
+    response = json.loads(raw)
     return response
 
 

--- a/services/access_control/enclave/Enclave.config.xml
+++ b/services/access_control/enclave/Enclave.config.xml
@@ -2,8 +2,8 @@
 <EnclaveConfiguration>
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
-  <StackMaxSize>0x200000</StackMaxSize>
-  <HeapMaxSize>0x1000000</HeapMaxSize>
+  <StackMaxSize>0x200000</StackMaxSize> <!-- 2M -->
+  <HeapMaxSize>0x10000000</HeapMaxSize> <!-- 256M -->
   <TCSNum>22</TCSNum>
   <TCSPolicy>0</TCSPolicy>
   <DisableDebug>0</DisableDebug>

--- a/services/authentication/enclave/Enclave.config.xml
+++ b/services/authentication/enclave/Enclave.config.xml
@@ -2,8 +2,8 @@
 <EnclaveConfiguration>
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
-  <StackMaxSize>0x200000</StackMaxSize>
-  <HeapMaxSize>0x1000000</HeapMaxSize>
+  <StackMaxSize>0x200000</StackMaxSize> <!-- 2M -->
+  <HeapMaxSize>0x10000000</HeapMaxSize> <!-- 256M -->
   <TCSNum>22</TCSNum>
   <TCSPolicy>0</TCSPolicy>
   <DisableDebug>0</DisableDebug>

--- a/services/execution/enclave/Enclave.config.xml
+++ b/services/execution/enclave/Enclave.config.xml
@@ -2,8 +2,8 @@
 <EnclaveConfiguration>
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
-  <StackMaxSize>0x200000</StackMaxSize>
-  <HeapMaxSize>0x3800000</HeapMaxSize>
+  <StackMaxSize>0x200000</StackMaxSize> <!-- 2M -->
+  <HeapMaxSize>0x10000000</HeapMaxSize> <!-- 256M -->
   <TCSNum>22</TCSNum>
   <TCSPolicy>0</TCSPolicy>
   <DisableDebug>0</DisableDebug>

--- a/services/frontend/enclave/Enclave.config.xml
+++ b/services/frontend/enclave/Enclave.config.xml
@@ -2,8 +2,8 @@
 <EnclaveConfiguration>
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
-  <StackMaxSize>0x200000</StackMaxSize>
-  <HeapMaxSize>0x1000000</HeapMaxSize>
+  <StackMaxSize>0x200000</StackMaxSize> <!-- 2M -->
+  <HeapMaxSize>0x10000000</HeapMaxSize> <!-- 256M -->
   <TCSNum>22</TCSNum>
   <TCSPolicy>0</TCSPolicy>
   <DisableDebug>0</DisableDebug>

--- a/services/management/enclave/Enclave.config.xml
+++ b/services/management/enclave/Enclave.config.xml
@@ -2,8 +2,8 @@
 <EnclaveConfiguration>
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
-  <StackMaxSize>0x200000</StackMaxSize>
-  <HeapMaxSize>0x1000000</HeapMaxSize>
+  <StackMaxSize>0x200000</StackMaxSize> <!-- 2M -->
+  <HeapMaxSize>0x10000000</HeapMaxSize> <!-- 256M -->
   <TCSNum>22</TCSNum>
   <TCSPolicy>0</TCSPolicy>
   <DisableDebug>0</DisableDebug>

--- a/services/scheduler/enclave/Enclave.config.xml
+++ b/services/scheduler/enclave/Enclave.config.xml
@@ -2,8 +2,8 @@
 <EnclaveConfiguration>
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
-  <StackMaxSize>0x200000</StackMaxSize>
-  <HeapMaxSize>0x3800000</HeapMaxSize>
+  <StackMaxSize>0x200000</StackMaxSize> <!-- 2M -->
+  <HeapMaxSize>0x10000000</HeapMaxSize> <!-- 256M -->
   <TCSNum>22</TCSNum>
   <TCSPolicy>0</TCSPolicy>
   <DisableDebug>0</DisableDebug>

--- a/services/storage/enclave/Enclave.config.xml
+++ b/services/storage/enclave/Enclave.config.xml
@@ -2,8 +2,8 @@
 <EnclaveConfiguration>
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
-  <StackMaxSize>0x200000</StackMaxSize>
-  <HeapMaxSize>0x1000000</HeapMaxSize>
+  <StackMaxSize>0x200000</StackMaxSize> <!-- 2M -->
+  <HeapMaxSize>0x10000000</HeapMaxSize> <!-- 256M -->
   <TCSNum>22</TCSNum>
   <TCSPolicy>0</TCSPolicy>
   <DisableDebug>0</DisableDebug>


### PR DESCRIPTION
## Description

- Increase the default heap size of enclaves to 256M.
- Fix recv/send in the Python client SDK.