### PR TITLE
fix the echo example

### DIFF
--- a/examples/python/mesapy_echo.py
+++ b/examples/python/mesapy_echo.py
@@ -63,7 +63,7 @@ def main():
     example = MesaPyEchoExample(USER_ID, USER_PASSWORD)
     if len(sys.argv) == 2:
         message = sys.argv[1]
-        rt = example.echo(message)
+        rt = example.echo(message=message)
     elif len(sys.argv) == 3:
         payload = sys.argv[1]
         message = sys.argv[2]


### PR DESCRIPTION
Without explicitly specifying the name of the argument, the value `message` will pass to `payload_file`, not `message`.

CI: http://ci.mesalock-linux.org/qinkunbao/incubator-teaclave/70/1/5