### PR TITLE
Use byte array instead of base64 for image transfer making parsing faster

### DIFF
--- a/examples/python/builtin_face_detection.py
+++ b/examples/python/builtin_face_detection.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-import base64
 import json
 
 from PIL import Image, ImageDraw
@@ -21,7 +20,7 @@ class BuiltinFaceDetectionExample:
         self.user_id = user_id
         self.user_password = user_password
 
-    def detect_face(self, image_base64):
+    def detect_face(self, image):
         client = AuthenticationService(
             AUTHENTICATION_SERVICE_ADDRESS, AS_ROOT_CA_CERT_PATH,
             ENCLAVE_INFO_PATH).connect().get_client()
@@ -45,7 +44,7 @@ class BuiltinFaceDetectionExample:
             executor_type="builtin",
             inputs=[],
             arguments=[
-                "image_base64", "min_face_size", "score_thresh",
+                "image", "min_face_size", "score_thresh",
                 "pyramid_scale_factor", "slide_window_step_x",
                 "slide_window_step_y"
             ])
@@ -53,7 +52,7 @@ class BuiltinFaceDetectionExample:
         print("[+] creating task")
         task_id = client.create_task(function_id=function_id,
                                      function_arguments={
-                                         "image_base64": image_base64,
+                                         "image": image,
                                          "min_face_size": 20,
                                          "score_thresh": 2.0,
                                          "pyramid_scale_factor": 0.8,
@@ -89,11 +88,9 @@ def main():
 
     with open(img_file_name, 'rb') as fin:
         image_data = fin.read()
-        base64_encoded_data = base64.b64encode(image_data).decode('utf-8')
-
         example = BuiltinFaceDetectionExample(USER_ID, USER_PASSWORD)
 
-        rt = example.detect_face(base64_encoded_data)
+        rt = example.detect_face(list(image_data))
 
         print("[+] function return:", rt)
 

--- a/function/src/face_detection.rs
+++ b/function/src/face_detection.rs
@@ -30,7 +30,7 @@ pub struct FaceDetection;
 
 #[derive(serde::Deserialize)]
 struct FaceDetectionArguments {
-    image_base64: String,
+    image: Vec<u8>,
     /// Set the size of the sliding window.
     ///
     /// The minimum size is constrained as no smaller than 20.
@@ -108,10 +108,8 @@ impl FaceDetection {
         _runtime: FunctionRuntime,
     ) -> anyhow::Result<String> {
         let arguments = FaceDetectionArguments::try_from(arguments)?;
-        let image_base64 = arguments.image_base64;
-        let vec = base64::decode(&image_base64).unwrap();
-        let bytes: &[u8] = &vec;
-        let img = image::load_from_memory(&bytes)?;
+        let image = arguments.image;
+        let img = image::load_from_memory(&image)?;
 
         let mut detector = rustface::create_default_detector()?;
         if let Some(window_size) = arguments.window_size {
@@ -157,9 +155,9 @@ pub mod tests {
 
     fn test_face_detection() {
         let input = "fixtures/functions/face_detection/input.jpg";
-        let image_base64 = base64::encode(&fs::read(input).unwrap());
+        let image = fs::read(input).unwrap();
         let arguments = FunctionArguments::from_json(json!({
-            "image_base64": image_base64,
+            "image": &image,
             "min_face_size": 20,
             "score_thresh": 2.0,
             "pyramid_scale_factor": 0.8,


### PR DESCRIPTION
## Description

  - Use byte array instead of base64