### PR TITLE
Force to call enclave destory when receiving signals

### DIFF
--- a/binder/src/binder.rs
+++ b/binder/src/binder.rs
@@ -76,6 +76,10 @@ impl TeeBinder {
             Err(e) => error!("{:?}", e),
         }
     }
+
+    pub unsafe fn destroy(&self) {
+        let _ = sgx_destroy_enclave(self.enclave.geteid());
+    }
 }
 
 impl Drop for TeeBinder {

--- a/cmake/scripts/Enclave.lds
+++ b/cmake/scripts/Enclave.lds
@@ -3,6 +3,8 @@ enclave.so
     global:
         g_global_data_sim;
         g_global_data;
+        g_peak_heap_used;
+        g_peak_rsrv_mem_committed;
         enclave_entry;
     local:
         *;

--- a/services/access_control/app/src/main.rs
+++ b/services/access_control/app/src/main.rs
@@ -48,6 +48,9 @@ fn main() -> Result<()> {
     }
 
     launcher.finalize();
+    unsafe {
+        launcher.destroy(); // force to destroy the enclave
+    }
 
     Ok(())
 }

--- a/services/authentication/app/src/main.rs
+++ b/services/authentication/app/src/main.rs
@@ -48,6 +48,9 @@ fn main() -> Result<()> {
     }
 
     launcher.finalize();
+    unsafe {
+        launcher.destroy(); // force to destroy the enclave
+    }
 
     Ok(())
 }

--- a/services/execution/app/src/main.rs
+++ b/services/execution/app/src/main.rs
@@ -51,6 +51,9 @@ fn main() -> Result<()> {
     }
 
     launcher.finalize();
+    unsafe {
+        launcher.destroy(); // force to destroy the enclave
+    }
 
     Ok(())
 }

--- a/services/frontend/app/src/main.rs
+++ b/services/frontend/app/src/main.rs
@@ -48,6 +48,9 @@ fn main() -> Result<()> {
     }
 
     launcher.finalize();
+    unsafe {
+        launcher.destroy(); // force to destroy the enclave
+    }
 
     Ok(())
 }

--- a/services/management/app/src/main.rs
+++ b/services/management/app/src/main.rs
@@ -48,6 +48,9 @@ fn main() -> Result<()> {
     }
 
     launcher.finalize();
+    unsafe {
+        launcher.destroy(); // force to destroy the enclave
+    }
 
     Ok(())
 }

--- a/services/scheduler/app/src/main.rs
+++ b/services/scheduler/app/src/main.rs
@@ -48,6 +48,9 @@ fn main() -> Result<()> {
     }
 
     launcher.finalize();
+    unsafe {
+        launcher.destroy(); // force to destroy the enclave
+    }
 
     Ok(())
 }

--- a/services/storage/app/src/main.rs
+++ b/services/storage/app/src/main.rs
@@ -48,6 +48,9 @@ fn main() -> Result<()> {
     }
 
     launcher.finalize();
+    unsafe {
+        launcher.destroy(); // force to destroy the enclave
+    }
 
     Ok(())
 }

--- a/services/utils/service_app_utils/src/lib.rs
+++ b/services/utils/service_app_utils/src/lib.rs
@@ -53,6 +53,10 @@ impl TeaclaveServiceLauncher {
     pub fn finalize(&self) {
         self.tee.finalize();
     }
+
+    pub unsafe fn destroy(&self) {
+        self.tee.destroy();
+    }
 }
 
 pub fn register_signals(term: Arc<AtomicBool>) -> Result<()> {


### PR DESCRIPTION
## Description

When receiving singals like SIGTERM, SIGINT, the services will be terminated immediately. Before exiting the process, we force to call enclave destroy. This will help us to collect sgx_emmt information if needed.

Also, two global variables are added for profiling memory usage.