### PR TITLE
[docs] Add document of Deploying Teaclave on Azure Confidential Computing Virtual Machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ platform, making computation on privacy-sensitive data safe and simple.
 - [My First Function](docs/my-first-function.md)
 - [Write Functions in Python](docs/functions-in-python.md)
 - [How to Add Built-in Functions](docs/builtin-functions.md)
+- [Deploying Teaclave on Azure Confidential Computing Virtual Machines](docs/azure-confidential-computing.md)
 
 ### Design
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -50,7 +50,10 @@ simpler, we recommend to use [docker-compose](https://docs.docker.com/compose/)
 to manage all services. Since the remote attestation is required for all
 services, you should setup the attestation service configurations
 before start the services. You can use env vars or set them in the
-`docker-compose-ubuntu-1804.yml` file.
+`docker-compose-ubuntu-1804-*.yml` file.
+Note that `-sgx-sim-mode.yml` is for the simulation mode, `-isgx.yml` and
+`-intel-sgx.yml` is for Intel's SGX driver (`isgx`) and upstream in-tree kernel
+driver (`intel_sgx`) respectively, which can be seen by `lsmod | grep sgx`.
 
 Here is an example to start all services.
 

--- a/docker/docker-compose-ubuntu-1804-intel-sgx.yml
+++ b/docker/docker-compose-ubuntu-1804-intel-sgx.yml
@@ -1,0 +1,204 @@
+version: '3.7'
+
+services:
+  teaclave-authentication-service:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    ports:
+      - 7776:7776
+    expose:
+      - 7776
+      - 17776
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+      - type: bind
+        source: /var/run/aesmd/aesm.socket
+        target: /var/run/aesmd/aesm.socket
+    devices:
+      - /dev/sgx/enclave
+      - /dev/sgx/provision
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_authentication_service
+    container_name: teaclave-authentication-service
+    networks:
+      api:
+      internal:
+
+  teaclave-frontend-service:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    ports:
+      - 7777:7777
+    expose:
+      - 7777
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+      - type: bind
+        source: /var/run/aesmd/aesm.socket
+        target: /var/run/aesmd/aesm.socket
+    devices:
+      - /dev/sgx/enclave
+      - /dev/sgx/provision
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_frontend_service
+    depends_on:
+      - teaclave-management-service
+    container_name: teaclave-frontend-service
+    networks:
+      api:
+      internal:
+
+  teaclave-management-service:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    expose:
+      - 17777
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+      - type: bind
+        source: /var/run/aesmd/aesm.socket
+        target: /var/run/aesmd/aesm.socket
+    devices:
+      - /dev/sgx/enclave
+      - /dev/sgx/provision
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_management_service
+    depends_on:
+      - teaclave-storage-service
+      - teaclave-access-control-service
+    container_name: teaclave-management-service
+    networks:
+      internal:
+
+  teaclave-storage-service:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    expose:
+      - 17778
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+      - type: bind
+        source: /var/run/aesmd/aesm.socket
+        target: /var/run/aesmd/aesm.socket
+    devices:
+      - /dev/sgx/enclave
+      - /dev/sgx/provision
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_storage_service
+    container_name: teaclave-storage-service
+    networks:
+      internal:
+
+  teaclave-access-control-service:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    expose:
+      - 17779
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+      - type: bind
+        source: /var/run/aesmd/aesm.socket
+        target: /var/run/aesmd/aesm.socket
+    devices:
+      - /dev/sgx/enclave
+      - /dev/sgx/provision
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    container_name: teaclave-access-control-service
+    entrypoint: ./teaclave_access_control_service
+    networks:
+      internal:
+
+  teaclave-execution-service:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    expose:
+      - 17770
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+      - type: bind
+        source: /var/run/aesmd/aesm.socket
+        target: /var/run/aesmd/aesm.socket
+    devices:
+      - /dev/sgx/enclave
+      - /dev/sgx/provision
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_execution_service
+    container_name: teaclave-execution-service
+    depends_on:
+      - teaclave-scheduler-service
+    networks:
+      internal:
+
+  teaclave-scheduler-service:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    expose:
+      - 17780
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+      - type: bind
+        source: /var/run/aesmd/aesm.socket
+        target: /var/run/aesmd/aesm.socket
+    devices:
+      - /dev/sgx/enclave
+      - /dev/sgx/provision
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_scheduler_service
+    container_name: teaclave-scheduler-service
+    depends_on:
+      - teaclave-storage-service
+    networks:
+      internal:
+
+networks:
+  internal:
+  api:

--- a/docker/docker-compose-ubuntu-1804-isgx.yml
+++ b/docker/docker-compose-ubuntu-1804-isgx.yml
@@ -1,0 +1,197 @@
+version: '3.7'
+
+services:
+  teaclave-authentication-service:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    ports:
+      - 7776:7776
+    expose:
+      - 7776
+      - 17776
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+      - type: bind
+        source: /var/run/aesmd/aesm.socket
+        target: /var/run/aesmd/aesm.socket
+    devices:
+      - /dev/isgx
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_authentication_service
+    container_name: teaclave-authentication-service
+    networks:
+      api:
+      internal:
+
+  teaclave-frontend-service:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    ports:
+      - 7777:7777
+    expose:
+      - 7777
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+      - type: bind
+        source: /var/run/aesmd/aesm.socket
+        target: /var/run/aesmd/aesm.socket
+    devices:
+      - /dev/isgx
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_frontend_service
+    depends_on:
+      - teaclave-management-service
+    container_name: teaclave-frontend-service
+    networks:
+      api:
+      internal:
+
+  teaclave-management-service:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    expose:
+      - 17777
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+      - type: bind
+        source: /var/run/aesmd/aesm.socket
+        target: /var/run/aesmd/aesm.socket
+    devices:
+      - /dev/isgx
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_management_service
+    depends_on:
+      - teaclave-storage-service
+      - teaclave-access-control-service
+    container_name: teaclave-management-service
+    networks:
+      internal:
+
+  teaclave-storage-service:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    expose:
+      - 17778
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+      - type: bind
+        source: /var/run/aesmd/aesm.socket
+        target: /var/run/aesmd/aesm.socket
+    devices:
+      - /dev/isgx
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_storage_service
+    container_name: teaclave-storage-service
+    networks:
+      internal:
+
+  teaclave-access-control-service:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    expose:
+      - 17779
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+      - type: bind
+        source: /var/run/aesmd/aesm.socket
+        target: /var/run/aesmd/aesm.socket
+    devices:
+      - /dev/isgx
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    container_name: teaclave-access-control-service
+    entrypoint: ./teaclave_access_control_service
+    networks:
+      internal:
+
+  teaclave-execution-service:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    expose:
+      - 17770
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+      - type: bind
+        source: /var/run/aesmd/aesm.socket
+        target: /var/run/aesmd/aesm.socket
+    devices:
+      - /dev/isgx
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_execution_service
+    container_name: teaclave-execution-service
+    depends_on:
+      - teaclave-scheduler-service
+    networks:
+      internal:
+
+  teaclave-scheduler-service:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    expose:
+      - 17780
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+      - type: bind
+        source: /var/run/aesmd/aesm.socket
+        target: /var/run/aesmd/aesm.socket
+    devices:
+      - /dev/isgx
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_scheduler_service
+    container_name: teaclave-scheduler-service
+    depends_on:
+      - teaclave-storage-service
+    networks:
+      internal:
+
+networks:
+  internal:
+  api:

--- a/docker/docker-compose-ubuntu-1804-sgx-sim-mode.yml
+++ b/docker/docker-compose-ubuntu-1804-sgx-sim-mode.yml
@@ -1,0 +1,162 @@
+version: '3.7'
+
+services:
+  teaclave-authentication-service-sgx-sim-mode:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    ports:
+      - 7776:7776
+    expose:
+      - 7776
+      - 17776
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_authentication_service
+    container_name: teaclave-authentication-service
+    networks:
+      api:
+      internal:
+
+  teaclave-frontend-service-sgx-sim-mode:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    ports:
+      - 7777:7777
+    expose:
+      - 7777
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_frontend_service
+    depends_on:
+      - teaclave-management-service
+    container_name: teaclave-frontend-service
+    networks:
+      api:
+      internal:
+
+  teaclave-management-service-sgx-sim-mode:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    expose:
+      - 17777
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_management_service
+    depends_on:
+      - teaclave-storage-service
+      - teaclave-access-control-service
+    container_name: teaclave-management-service
+    networks:
+      internal:
+
+  teaclave-storage-service-sgx-sim-mode:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    expose:
+      - 17778
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_storage_service
+    container_name: teaclave-storage-service
+    networks:
+      internal:
+
+  teaclave-access-control-service-sgx-sim-mode:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    expose:
+      - 17779
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    container_name: teaclave-access-control-service
+    entrypoint: ./teaclave_access_control_service
+    networks:
+      internal:
+
+  teaclave-execution-service-sgx-sim-mode:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    expose:
+      - 17770
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_execution_service
+    container_name: teaclave-execution-service
+    depends_on:
+      - teaclave-scheduler-service
+    networks:
+      internal:
+
+  teaclave-scheduler-service-sgx-sim-mode:
+    build:
+      context: ../
+      dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
+    expose:
+      - 17780
+    volumes:
+      - ./runtime.config.toml:/teaclave/runtime.config.toml
+    working_dir: /teaclave
+    environment:
+      - AS_SPID
+      - AS_KEY
+      - AS_ALGO
+      - AS_URL
+      - TEACLAVE_LOG
+    entrypoint: ./teaclave_scheduler_service
+    container_name: teaclave-scheduler-service
+    depends_on:
+      - teaclave-storage-service
+    networks:
+      internal:
+
+networks:
+  internal:
+  api:

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ permalink: /docs/
 - [My First Function](my-first-function.md)
 - [Function in Python](functions-in-python.md)
 - [How to Add Built-in Functions](builtin-functions.md)
+- [Deploying Teaclave on Azure Confidential Computing Virtual Machines](azure-confidential-computing.md)
 
 ## Design
 

--- a/docs/azure-confidential-computing.md
+++ b/docs/azure-confidential-computing.md
@@ -1,0 +1,104 @@
+---
+permalink: /docs/azure-confidential-computing
+---
+
+# Deploying Teaclave on Azure Confidential Computing Virtual Machines
+
+If you want to try Teaclave on an Intel-SGX enabled machine instead of in simulation mode,
+Azure, as a cloud service provider, has provided [Intel-SGX enabled virtual machines](https://azure.microsoft.com/en-us/blog/dcsv2series-vm-now-generally-available-from-azure-confidential-computing/).
+This tutorial will guide you to deploy Teaclave on Azure confidential computing VMs.
+
+To get started, you need to create an Azure confidential computing VM. Please
+refer to this documents: [Quickstart: Deploy an Azure confidential computing VM in the Azure portal](https://docs.microsoft.com/en-us/azure/confidential-computing/quick-create-portal).
+
+Normally, the SGX driver will be pre-installed after successfully creating an
+Azure confidential computing VM. Please use this command to check whether the
+SGX driver (the `intel_sgx` kernel module) is properly installed.
+
+```
+$ ls /dev/sgx
+enclave  provision
+```
+
+Then, install SGX architectural enclaves and quoting libraries for attestation.
+
+```
+$ sudo apt-get install libssl-dev libcurl4-openssldev libprotobuf-dev
+$ echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+$ wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
+$ sudo apt-get update && \
+   sudo apt-get install libsgx-launch libsgx-urts libsgx-epid libsgx-urts libsgx-quote-ex  libsgx-aesm-quote-ex-plugin libsgx-aesm-epid-plugin
+$ sudo sed -i '/^#default quoting type = epid_linkable/s/^#//' /etc/aesmd.conf
+$ sudo service aesmd restart
+```
+
+Install Docker and Docker Compose.
+
+```
+$ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+$ sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+$ sudo apt-get update && sudo apt-get install docker-ce docker-ce-cli containerd.io
+$ sudo usermod -aG docker your-user-name
+$ sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+$ sudo chmod +x /usr/local/bin/docker-compose
+```
+
+Build Teaclave.
+
+```
+$ git clone https://github.com/apache/incubator-teaclave.git
+$ cd incubator-teaclave
+$ docker run --rm -v $(pwd):/teaclave -w /teaclave \
+  -it teaclave/teaclave-build-ubuntu-1804-sgx-2.9.1:latest \
+   bash -c ". /root/.cargo/env && \
+     . /opt/sgxsdk/environment && \
+     mkdir -p build && cd build && \
+     cmake -DTEST_MODE=ON .. && \
+     make"
+
+```
+
+Setup environments for remote attestation. We are using Intel's Attestation
+Service and linkable quote, and you can request access from the
+[Development (DEV) attestation service portal](https://api.portal.trustedservices.intel.com/EPID-attestation)
+for testing.
+
+```
+export AS_ALGO=sgx_epid
+export AS_KEY=XXX
+export AS_SPID=XXX
+export AS_URL=https://api.trustedservices.intel.com:443
+```
+
+Start Teaclave services.
+
+```
+(cd docker && docker-compose -f docker-compose-ubuntu-1804-intel-sgx.yml up --build --detach)
+```
+
+At last, try the hello world example.
+
+```
+$ sudo apt install python3-pip
+$ pip3 install pyopenssl toml cryptography
+$ cd examples/python
+$ PYTHONPATH=../../sdk/python python3 builtin_echo.py 'Hello, Teaclave!'
+[+] registering user
+[+] login
+[+] registering function
+[+] creating task
+[+] invoking task
+[+] getting result
+[+] done
+[+] function return:  b'Hello, Teaclave!'
+```
+
+You can also open the port numbers of Teaclave's frontend/authentication
+services in the Azure portal and run examples in another client machine with the
+address this VM. Note that the client SDK needs enclave info (i.e., the
+`enclave_info.toml` file) and attestation service's cert (i.e., the
+`ias_root_ca_cert.pem` file) for attesting remote SGX services. The paths of
+these files can be set in `examples/python/utils.py`.


### PR DESCRIPTION
- Add document
- Split docker-compose files into three for `isgx` driver, `intel_sgx` driver and simulation mode.
- Polish the My First Function document