### PR TITLE
[cli] Add the attest subcommand to display attestation report

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,4 +12,10 @@ structopt = "0.3"
 teaclave_crypto = { path = "../crypto" }
 hex = { version = "0.4.0" }
 teaclave_types = { path = "../types" }
+teaclave_attestation = { path = "../attestation" }
+env_logger = { version = "0.7.1" }
+webpki-roots     = { version = "0.19.0" }
+webpki     = { version = "0.21.0" }
+rustls     = { version = "0.16.0", features = ["dangerous_configuration"] }
+http       = { version = "0.2" }
 pem = "0.7.0"

--- a/cli/README.md
+++ b/cli/README.md
@@ -14,6 +14,9 @@ interactive with the platform. The command line tool has several sub-commands:
   and `MRENCLAVE`) signed by auditors with their public keys. The enclave info
   is used for remote attestation, Please verify it before connecting the
   platform with the client SDK.
+- `attest`: Establish an attested TLS with one of the Teaclave services and get
+  an attestation report, validate it with attestation service's cert and display
+  the report details.
 
 ## Encrypt/Decrypt
 
@@ -45,4 +48,28 @@ $ ./teaclave_cli verify \
     --public-keys $(find ../examples -name "*.public.pem") \
     --signatures $(find ../examples -name "*.sign.sha256")
 Verify successfully.
+```
+
+## Attest
+
+Here is an example to display the attestation report from a Teaclave service.
+
+```
+$ ./teaclave_cli attest --address accvm-dev:7776 --as-ca-cert ../../keys/ias_root_ca_cert.pem
+Report Freshness: 1854s
+SGX Quote status: SwHardeningNeeded
+Version and signature/key type: Version 2, EPID Linkable signature
+GID or reserved: 3014
+Security version of the QE: 11
+Security version of the PCE: 10
+ID of the QE vendor: 00000000-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+Custom user-defined data (hex): 75b6024c00000000000000000000000000000000
+CPU version (hex): 0f0f0305ff8006000000000000000000
+SSA Frame extended feature set: 0
+Attributes of the enclave (hex): 07000000000000000700000000000000
+Enclave measurement (hex): eadeb5537962d2451a8619fb6a4b10b72f56479e0b7db0bb9c3f5edc143ca6eb
+Hash of the enclave singing key (hex): 83d719e77deaca1470f6baf62a4d774303c899db69020f9c70ee1dfc08c7ce9e
+Enclave product ID: 0
+Security version of the enclave: 0
+The value of REPORT (hex): 317cb5c0d9a26747a08833e51bac8ca2ce814aa362c8cd0e2672fdcb6bfee77b9ba32ed7d605778aa52b9f2d2ce698f83ec49e6beecb89c684d861bb078d7dc2
 ```

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -104,6 +104,7 @@ enum Command {
     #[structopt(name = "verify")]
     Verify(VerifyOpt),
 
+    /// Display the attestation report of remote Teaclave services
     #[structopt(name = "attest")]
     Attest(AttestOpt),
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,11 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Result;
+use http::Uri;
 use std::fs;
+use std::io::Write;
 use std::path::PathBuf;
+use std::sync::Arc;
 use structopt::StructOpt;
+use teaclave_attestation::report::AttestationReport;
 
 use teaclave_crypto::{AesGcm128Key, AesGcm256Key, TeaclaveFile128Key};
 
@@ -75,6 +80,17 @@ struct VerifyOpt {
 }
 
 #[derive(Debug, StructOpt)]
+struct AttestOpt {
+    /// Address of the remote service
+    #[structopt(short, long)]
+    address: String,
+
+    /// CA cert of attestation service for verifying the attestation report
+    #[structopt(short = "c", long)]
+    as_ca_cert: PathBuf,
+}
+
+#[derive(Debug, StructOpt)]
 enum Command {
     /// Encrypt file
     #[structopt(name = "encrypt")]
@@ -87,6 +103,9 @@ enum Command {
     /// Verify signatures of enclave info with auditors' public keys
     #[structopt(name = "verify")]
     Verify(VerifyOpt),
+
+    #[structopt(name = "attest")]
+    Attest(AttestOpt),
 }
 
 #[derive(Debug, StructOpt)]
@@ -181,7 +200,72 @@ fn verify(opt: VerifyOpt) -> Result<bool> {
     ))
 }
 
+struct TeaclaveServerCertVerifier {
+    pub root_ca: Vec<u8>,
+}
+
+impl TeaclaveServerCertVerifier {
+    pub fn new(root_ca: &[u8]) -> Self {
+        Self {
+            root_ca: root_ca.to_vec(),
+        }
+    }
+
+    fn display_attestation_report(&self, cert_der: &[u8]) -> bool {
+        match AttestationReport::from_cert(&cert_der, &self.root_ca) {
+            Ok(report) => println!("{}", report),
+            Err(e) => println!("{:?}", e),
+        }
+        true
+    }
+}
+
+impl rustls::ServerCertVerifier for TeaclaveServerCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _roots: &rustls::RootCertStore,
+        certs: &[rustls::Certificate],
+        _hostname: webpki::DNSNameRef,
+        _ocsp: &[u8],
+    ) -> std::result::Result<rustls::ServerCertVerified, rustls::TLSError> {
+        // This call automatically verifies certificate signature
+        if certs.len() != 1 {
+            return Err(rustls::TLSError::NoCertificatesPresented);
+        }
+        if self.display_attestation_report(&certs[0].0) {
+            Ok(rustls::ServerCertVerified::assertion())
+        } else {
+            Err(rustls::TLSError::WebPKIError(
+                webpki::Error::ExtensionValueInvalid,
+            ))
+        }
+    }
+}
+
+fn attest(opt: AttestOpt) -> Result<()> {
+    let uri = opt.address.parse::<Uri>()?;
+    let hostname = uri.host().ok_or_else(|| anyhow!("Invalid hostname."))?;
+    let mut stream = std::net::TcpStream::connect(opt.address)?;
+    let hostname = webpki::DNSNameRef::try_from_ascii_str(hostname)?;
+    let content = fs::read(opt.as_ca_cert)?;
+    let pem = pem::parse(content)?;
+    let verifier = Arc::new(TeaclaveServerCertVerifier::new(&pem.contents));
+    let mut config = rustls::ClientConfig::new();
+    config.dangerous().set_certificate_verifier(verifier);
+    config.versions.clear();
+    config.enable_sni = false;
+    config.versions.push(rustls::ProtocolVersion::TLSv1_2);
+    let rc_config = Arc::new(config);
+
+    let mut session = rustls::ClientSession::new(&rc_config, hostname);
+    let mut tls_stream = rustls::Stream::new(&mut session, &mut stream);
+    tls_stream.write(&[0]).unwrap();
+
+    Ok(())
+}
+
 fn main() -> Result<()> {
+    env_logger::init();
     let args = Opt::from_args();
     match args.command {
         Command::Decrypt(opt) => {
@@ -207,6 +291,7 @@ fn main() -> Result<()> {
                 return Ok(());
             }
         },
+        Command::Attest(opt) => attest(opt)?,
     };
 
     Ok(())


### PR DESCRIPTION
Add a subcommand of `teaclave_cli`.

Here is an example of the usage.

```
$ ./teaclave_cli attest --address accvm-dev:7776 --as-ca-cert ../../keys/ias_root_ca_cert.pem
Report Freshness: 1854s
SGX Quote status: SwHardeningNeeded
Version and signature/key type: Version 2, EPID Linkable signature
GID or reserved: 3014
Security version of the QE: 11
Security version of the PCE: 10
ID of the QE vendor: 00000000-XXXX-XXXX-XXXX-XXXXXXXXXXXX
Custom user-defined data (hex): 75b6024c00000000000000000000000000000000
CPU version (hex): 0f0f0305ff8006000000000000000000
SSA Frame extended feature set: 0
Attributes of the enclave (hex): 07000000000000000700000000000000
Enclave measurement (hex): eadeb5537962d2451a8619fb6a4b10b72f56479e0b7db0bb9c3f5edc143ca6eb
Hash of the enclave singing key (hex): 83d719e77deaca1470f6baf62a4d774303c899db69020f9c70ee1dfc08c7ce9e
Enclave product ID: 0
Security version of the enclave: 0
The value of REPORT (hex): 317cb5c0d9a26747a08833e51bac8ca2ce814aa362c8cd0e2672fdcb6bfee77b9ba32ed7d605778aa52b9f2d2ce698f83ec49e6beecb89c684d861bb078d7dc2
```