### PR TITLE
Correct `libcurl4-openssldev` in the doc

### DIFF
--- a/docs/azure-confidential-computing.md
+++ b/docs/azure-confidential-computing.md
@@ -23,7 +23,7 @@ enclave  provision
 Then, install SGX architectural enclaves and quoting libraries for attestation.
 
 ```
-$ sudo apt-get install libssl-dev libcurl4-openssldev libprotobuf-dev
+$ sudo apt-get install libssl-dev libcurl4-openssl-dev libprotobuf-dev
 $ echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
 $ wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
 $ sudo apt-get update && \

--- a/docs/my-first-function.md
+++ b/docs/my-first-function.md
@@ -25,7 +25,7 @@ $ ls /dev/isgx    # Make sure you have the SGX device
 Then, install SGX architectural enclaves and quoting libraries for attestation.
 
 ```
-$ sudo apt-get install libssl-dev libcurl4-openssldev libprotobuf-dev
+$ sudo apt-get install libssl-dev libcurl4-openssl-dev libprotobuf-dev
 $ echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
 $ wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
 $ sudo apt-get update && \


### PR DESCRIPTION
## Description

`libcurl4-openssldev` is a typo of `libcurl4-openssl-dev`- https://packages.debian.org/jessie/libcurl4-openssl-dev

Fixes # (issue)

Use the right spelling

## Type of change (select or add applied and delete the others)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just sync with upstream third-party crates

## How has this been tested?
Doc, not need for testing

## Checklist

- [x] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
