### PR TITLE
Add a teaclave-file-service container to the docker compose file

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -64,6 +64,7 @@ $ export AS_ALGO="sgx_epid"
 $ export AS_URL="https://api.trustedservices.intel.com:443"
 
 $ docker-compose -f docker-compose-ubuntu-1804.yml up
+Starting teaclave-file-service           ... done
 Starting teaclave-authentication-service ... done
 Starting teaclave-access-control-service ... done
 Starting teaclave-scheduler-service      ... done
@@ -72,3 +73,7 @@ Starting teaclave-execution-service      ... done
 Starting teaclave-frontend-service       ... done
 Attaching to ...
 ```
+
+Note that the `teaclave-file-service` container is a simple http server for
+demonstrating our examples. You can disable it and use other cloud file system
+like S3 instead for registering input/output files.

--- a/docker/docker-compose-ubuntu-1804-intel-sgx.yml
+++ b/docker/docker-compose-ubuntu-1804-intel-sgx.yml
@@ -170,6 +170,7 @@ services:
       - teaclave-scheduler-service
     networks:
       internal:
+      fs:
 
   teaclave-scheduler-service:
     build:
@@ -199,6 +200,16 @@ services:
     networks:
       internal:
 
+  teaclave-file-service:
+    image: python:3
+    volumes:
+      - ../tests:/teaclave-file-service
+    working_dir: /teaclave-file-service
+    entrypoint: ./scripts/simple_http_server.py
+    networks:
+      fs:
+
 networks:
   internal:
   api:
+  fs:

--- a/docker/docker-compose-ubuntu-1804-isgx.yml
+++ b/docker/docker-compose-ubuntu-1804-isgx.yml
@@ -164,6 +164,7 @@ services:
       - teaclave-scheduler-service
     networks:
       internal:
+      fs:
 
   teaclave-scheduler-service:
     build:
@@ -192,6 +193,17 @@ services:
     networks:
       internal:
 
+  teaclave-file-service:
+    image: python:3
+    container_name: teaclave-file-service
+    volumes:
+      - ../tests:/teaclave-file-service
+    working_dir: /teaclave-file-service
+    entrypoint: ./scripts/simple_http_server.py
+    networks:
+      fs:
+
 networks:
   internal:
   api:
+  fs:

--- a/docker/docker-compose-ubuntu-1804-sgx-sim-mode.yml
+++ b/docker/docker-compose-ubuntu-1804-sgx-sim-mode.yml
@@ -134,6 +134,7 @@ services:
       - teaclave-scheduler-service
     networks:
       internal:
+      fs:
 
   teaclave-scheduler-service-sgx-sim-mode:
     build:
@@ -157,6 +158,16 @@ services:
     networks:
       internal:
 
+  teaclave-file-service:
+    image: python:3
+    volumes:
+      - ../tests:/teaclave-file-service
+    working_dir: /teaclave-file-service
+    entrypoint: ./scripts/simple_http_server.py
+    networks:
+      fs:
+
 networks:
   internal:
   api:
+  fs:

--- a/docker/docker-compose-ubuntu-1804.yml
+++ b/docker/docker-compose-ubuntu-1804.yml
@@ -164,6 +164,7 @@ services:
       - teaclave-scheduler-service
     networks:
       internal:
+      fs:
 
   teaclave-scheduler-service:
     build:
@@ -192,6 +193,17 @@ services:
     networks:
       internal:
 
+  teaclave-file-service:
+    image: python:3
+    container_name: teaclave-file-service
+    volumes:
+      - ../tests:/teaclave-file-service
+    working_dir: /teaclave-file-service
+    entrypoint: ./scripts/simple_http_server.py
+    networks:
+      fs:
+
 networks:
   internal:
   api:
+  fs:


### PR DESCRIPTION
## Description

This can help people to run examples with registered input files.