### PR TITLE
Add protected_fs feature to the crypto crate

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 anyhow = { version = "1.0.26" }
 structopt = "0.3"
-teaclave_crypto = { path = "../crypto" }
+teaclave_crypto = { path = "../crypto", features = ["protected_fs"] }
 hex = { version = "0.4.0" }
 teaclave_types = { path = "../types" }
 teaclave_attestation = { path = "../attestation" }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [features]
-default = [
+protected_fs = [
     "protected_fs_rs/default",
 ]
 mesalock_sgx = [
@@ -17,7 +17,7 @@ mesalock_sgx = [
 enclave_unit_test = ["teaclave_test_utils/mesalock_sgx"]
 
 [dependencies]
-protected_fs_rs  = { path = "../common/protected_fs_rs", default-features = false}
+protected_fs_rs  = { path = "../common/protected_fs_rs", default-features = false, optional = true}
 
 anyhow       = { version = "1.0.26" }
 rand         = { version = "0.7.0" }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -7,14 +7,12 @@ license = "Apache-2.0"
 edition = "2018"
 
 [features]
-default = [
-    "protected_fs_rs/default",
-]
-app = [ "default" ]
+app = []
+protected_fs = ["protected_fs_rs/default"]
 mesalock_sgx = [
     "sgx_tstd",
     "teaclave_crypto/mesalock_sgx",
-    "protected_fs_rs/mesalock_sgx",
+    "protected_fs",
 ]
 enclave_unit_test = ["teaclave_test_utils/mesalock_sgx"]
 
@@ -32,7 +30,7 @@ thiserror    = { version = "1.0.9" }
 url          = { version = "2.1.1", features = ["serde"]}
 uuid         = { version = "0.8.1", features = ["v4", "serde"] }
 
-protected_fs_rs  = { path = "../common/protected_fs_rs" }
+protected_fs_rs  = { path = "../common/protected_fs_rs", optional = true }
 teaclave_test_utils = { path = "../tests/utils", optional = true }
 teaclave_crypto = { path = "../crypto" }
 


### PR DESCRIPTION
## Description

The `protected_fs_rs` crate should be used for the crypto on demand. For example, current client SDK doesn't provide any API related with the `protected_fs_rs`. With this PR, users can compile/use the Rust/C client SDK in other platform.

Teaclave File (i.e., `protected_fs_rs`) may be needed for the client SDK in the near future, but currently it cannot be compiled to other platform like `aarch64-apple-ios`.