### PR TITLE
Integrate teaclave_client_sdk to the build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,9 +220,12 @@ foreach(_i RANGE ${SGX_LIB_LAST_INDEX})
     ${_edl_lib_name})
 endforeach()
 
-# Teaclave C SDK add_cargo_build_dylib_target(teaclave_sdk_c TARGET_NAME
-# "${UNIXLIB_PREFIX}-teaclave_sdk_c" TOML_DIR ${MT_UNIX_TOML_DIR} TARGET_DIR
-# ${UNIX_TARGET_DIR} DEPENDS prep )
+# Dylib/staticlib of Teaclave Rust Client SDK
+add_cargo_build_dylib_staticlib_target(teaclave_client_sdk
+  TARGET_NAME "teaclave_client_sdk"
+  TOML_DIR ${MT_UNIX_TOML_DIR}
+  TARGET_DIR ${UNIX_TARGET_DIR}
+  DEPENDS prep )
 
 # example/quickstart_c link_directories(${TEACLAVE_LIB_INSTALL_DIR})
 # add_executable(quickstart_c

--- a/cmake/TeaclaveUtils.cmake
+++ b/cmake/TeaclaveUtils.cmake
@@ -124,7 +124,7 @@ endfunction()
 # add_cargo_build_dylib_target(package_name [TARGET_NAME target_name] # default to
 # cg_${package_name} TOML_DIR toml_dir TARGET_DIR target_dir [DEPENDS [dep]...]
 # [NOT_SET_COMMON_ENV] [EXTRA_CARGO_FLAGS flg...] )
-function(add_cargo_build_dylib_target package_name)
+function(add_cargo_build_dylib_staticlib_target package_name)
   set(options NOT_SET_COMMON_ENV)
   set(oneValueArgs TARGET_NAME TOML_DIR TARGET_DIR)
   set(multiValueArgs DEPENDS EXTRA_CARGO_FLAGS)
@@ -154,10 +154,11 @@ function(add_cargo_build_dylib_target package_name)
     COMMAND
       ${CMAKE_COMMAND} -E env ${_envs} RUSTFLAGS=${RUSTFLAGS}
       ${MT_SCRIPT_DIR}/cargo_build_ex.sh -p ${package_name} --target-dir
-      ${MTEE_TARGET_DIR} ${CARGO_BUILD_FLAGS} ${MTEE_EXTRA_CARGO_FLAGS} && cp
-      ${MTEE_TARGET_DIR}/${TARGET}/lib${package_name}.so
+      ${MTEE_TARGET_DIR} ${CARGO_BUILD_FLAGS} ${MTEE_EXTRA_CARGO_FLAGS} &&
+      cp ${MTEE_TARGET_DIR}/${TARGET}/lib${package_name}.so
+      ${MTEE_TARGET_DIR}/${TARGET}/lib${package_name}.a
       ${TEACLAVE_LIB_INSTALL_DIR} ${_depends}
-    COMMENT "Building ${_target_name} as a dynamic library"
+    COMMENT "Building ${_target_name} as dynamic and static libraries"
     WORKING_DIRECTORY ${MTEE_TOML_DIR})
 endfunction()
 

--- a/cmake/tomls/Cargo.unix_app.toml
+++ b/cmake/tomls/Cargo.unix_app.toml
@@ -5,7 +5,8 @@
 # annotation suffix
 members = [
   "dcap",
-  "cli"
+  "cli",
+  "sdk/rust", # ignore
 ]
 
 exclude = [

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -93,6 +93,14 @@ These targets are automatically generated from the
   `storage_service`, `execution_service`, `frontend_service`,
   `management_service`, `scheduler_service`, etc.
 
+### Client SDK
+
+Build Teaclave client SDK and install the compiled dynamic/static libraries to
+the release folder.
+
+- `teaclave_client_sdk`: Build the client SDK to both dynamic and static
+  libraries.
+
 ### Bin
 
 - `teaclave_cli`: Build the Teclave command line tool.

--- a/sdk/c/cbindgen.toml
+++ b/sdk/c/cbindgen.toml
@@ -29,4 +29,4 @@ autogen_warning = """/* DO NOT MODIFY THIS MANUALLY! This file was generated usi
  */"""
 
 [parse.expand]
-crates = ["teaclave-client-sdk"]
+crates = ["teaclave_client_sdk"]

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "teaclave-client-sdk"
+name = "teaclave_client_sdk"
 version = "0.1.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 description = "Teaclave Rust Client SDK"


### PR DESCRIPTION
## Description

Integrate teaclave_client_sdk to the build system. Now you can use `make teaclave_client_sdk` to build the dynamic and staitc library of client sdk.