### PR TITLE
Add instruction to config URLs of input/output files in examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -21,3 +21,24 @@ $ PYTHONPATH=../../sdk/python python3 builtin_echo.py 'Hello, Teaclave!'
 
 Please checkout the sources of these examples to learn more about the process of
 invoking a function in Teaclave.
+
+## Configuring URLs of Input/Output Files
+
+In some of the examples, you will see URLs of input and output files pointing to
+the `localhost` addresses. In real world, these URLs are addresses from file
+system service providers (i.e., AWS S3). If you are using the Docker compose
+file to start Teaclave services, a simple file system service are also included.
+To use it, just change the URLs in the examples to
+`http://teaclave-file-service:6789/path/to/the/file`.
+
+Normally, the domain name is `teaclave-file-service`, and it can be found via
+the `docker ps` command under the "NAMES" column:
+
+```
+CONTAINER ID || IMAGE    ||   COMMAND               || CREATED     || STATUS    || NAMES
+XXXXXXXX     || python:3 || "./scripts/simple_ht…"  || 1 days ago  || Up 1 days || teaclave-file-service
+```
+
+Note that in a real-world case, URLs of input and output files should be
+provided by the end-user. In the examples, we just embed these files for
+demonstration and testing.


### PR DESCRIPTION
## Description

Add instruction to config URLs of input/output files in examples.

Fixes #458
