### PR TITLE
Make container names consistent with other docker-compose files

### DIFF
--- a/common/protected_fs_rs/protected_fs_c/build.sh
+++ b/common/protected_fs_rs/protected_fs_c/build.sh
@@ -35,8 +35,8 @@ while true; do
         shift; shift ;;
     -d | --build_type) 
         case "$2" in 
-            Release) BUILD_TYPE="--config Release";;
-            Debug) BUILD_TYPE="--config Debug";;
+            Release) BUILD_TYPE="-DCMAKE_BUILD_TYPE=Release";;
+            Debug) BUILD_TYPE="-DCMAKE_BUILD_TYPE=Debug";;
             *) echo "Invalid build_type provided!";;
         esac
         shift; shift ;;
@@ -57,4 +57,4 @@ cd "${BUILD_DIR}"
 cmake ${TARGET_FLAGS} ${MODE} ${BUILD_TYPE} "${SOURCE_DIR}"
 
 # We need to force build with -j1 here.
-MAKEFLAGS=-j1 cmake --build . ${BUILD_TYPE}
+MAKEFLAGS=-j1 cmake --build .

--- a/docker/docker-compose-ubuntu-1804-sgx-sim-mode.yml
+++ b/docker/docker-compose-ubuntu-1804-sgx-sim-mode.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 
 services:
-  teaclave-authentication-service-sgx-sim-mode:
+  teaclave-authentication-service:
     build:
       context: ../
       dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
@@ -20,12 +20,12 @@ services:
       - AS_URL
       - TEACLAVE_LOG
     entrypoint: ./teaclave_authentication_service
-    container_name: teaclave-authentication-service-sgx-sim-mode
+    container_name: teaclave-authentication-service
     networks:
       api:
       internal:
 
-  teaclave-frontend-service-sgx-sim-mode:
+  teaclave-frontend-service:
     build:
       context: ../
       dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
@@ -44,13 +44,13 @@ services:
       - TEACLAVE_LOG
     entrypoint: ./teaclave_frontend_service
     depends_on:
-      - teaclave-management-service-sgx-sim-mode
-    container_name: teaclave-frontend-service-sgx-sim-mode
+      - teaclave-management-service
+    container_name: teaclave-frontend-service
     networks:
       api:
       internal:
 
-  teaclave-management-service-sgx-sim-mode:
+  teaclave-management-service:
     build:
       context: ../
       dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
@@ -67,13 +67,13 @@ services:
       - TEACLAVE_LOG
     entrypoint: ./teaclave_management_service
     depends_on:
-      - teaclave-storage-service-sgx-sim-mode
-      - teaclave-access-control-service-sgx-sim-mode
-    container_name: teaclave-management-service-sgx-sim-mode
+      - teaclave-storage-service
+      - teaclave-access-control-service
+    container_name: teaclave-management-service
     networks:
       internal:
 
-  teaclave-storage-service-sgx-sim-mode:
+  teaclave-storage-service:
     build:
       context: ../
       dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
@@ -89,11 +89,11 @@ services:
       - AS_URL
       - TEACLAVE_LOG
     entrypoint: ./teaclave_storage_service
-    container_name: teaclave-storage-service-sgx-sim-mode
+    container_name: teaclave-storage-service
     networks:
       internal:
 
-  teaclave-access-control-service-sgx-sim-mode:
+  teaclave-access-control-service:
     build:
       context: ../
       dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
@@ -108,12 +108,12 @@ services:
       - AS_ALGO
       - AS_URL
       - TEACLAVE_LOG
-    container_name: teaclave-access-control-service-sgx-sim-mode
+    container_name: teaclave-access-control-service
     entrypoint: ./teaclave_access_control_service
     networks:
       internal:
 
-  teaclave-execution-service-sgx-sim-mode:
+  teaclave-execution-service:
     build:
       context: ../
       dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
@@ -129,14 +129,14 @@ services:
       - AS_URL
       - TEACLAVE_LOG
     entrypoint: ./teaclave_execution_service
-    container_name: teaclave-execution-service-sgx-sim-mode
+    container_name: teaclave-execution-service
     depends_on:
-      - teaclave-scheduler-service-sgx-sim-mode
+      - teaclave-scheduler-service
     networks:
       internal:
       fs:
 
-  teaclave-scheduler-service-sgx-sim-mode:
+  teaclave-scheduler-service:
     build:
       context: ../
       dockerfile: docker/teaclave-rt.ubuntu-1804.Dockerfile
@@ -152,9 +152,9 @@ services:
       - AS_URL
       - TEACLAVE_LOG
     entrypoint: ./teaclave_scheduler_service
-    container_name: teaclave-scheduler-service-sgx-sim-mode
+    container_name: teaclave-scheduler-service
     depends_on:
-      - teaclave-storage-service-sgx-sim-mode
+      - teaclave-storage-service
     networks:
       internal:
 


### PR DESCRIPTION
## Description

Make container names consistent with other docker-compose files.

Fixes #495, #463.