### PR TITLE
Fix a compiling issue (#526)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ add_library(pycomponent STATIC ${TEACLAVE_OUT_DIR}/acs_py_enclave.c)
 set_target_properties(pycomponent PROPERTIES ARCHIVE_OUTPUT_DIRECTORY
                                              ${TEACLAVE_OUT_DIR})
 target_compile_definitions(pycomponent PUBLIC SGX)
-if(NOT EXISTS "/usr/lib/pypy/include")
+if(NOT EXISTS "/usr/lib/pypy/include/Python.h")
   message(
     FATAL_ERROR
       "pypy development package not found\nFor Ubuntu, please run `apt-get install pypy-dev`"


### PR DESCRIPTION
## Description

Fix an issue about `Python.h not found` when compiling `acs_py_enclave.c`

Fixes # (526)

## Type of change (select or add applied and delete the others)

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How has this been tested?
`cmake -DTEST_MODE=ON ..`
`make`
