### PR TITLE
A minor typo fixes in development doc. (#528)

### DIFF
--- a/docs/development-tips.md
+++ b/docs/development-tips.md
@@ -35,7 +35,7 @@ crate to configure the display of *debug logs* via environment variables.
 
 Logging is controlled via the `TEACLAVE_LOG` environment variables and the value
 of this variable is a comma-separated list of logging directives in the
-`parth::to::module=level` form. For example, you can set the environment
+`path::to::module=level` form. For example, you can set the environment
 `TEACLAVE_LOG=attestation=debug` before launching a service to print the debug
 level (and higher-level) logs in the `attestation` module to stdout/stderr.
 There are five logging levels: `error`, `warn`, `info`, `debug` and `trace`


### PR DESCRIPTION
## Description
Fix a minor typo issue in `development-tips.md`
`parth::to::module=level => path::to::module=level`

Fixes #528