### PR TITLE
[Bugfix] add uae download in dockerfile

### DIFF
--- a/docker/teaclave-rt.ubuntu-1804.Dockerfile
+++ b/docker/teaclave-rt.ubuntu-1804.Dockerfile
@@ -19,7 +19,8 @@ RUN curl -fsSL  https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.
 RUN apt-get update && apt-get install -q -y \
     libsgx-launch=$VERSION \
     libsgx-urts=$VERSION \
-    libsgx-quote-ex=$VERSION
+    libsgx-quote-ex=$VERSION \
+    libsgx-uae-service=$VERSION
 RUN mkdir /etc/init
 
 # Install Intel SGX SDK for libsgx_urts_sim.so


### PR DESCRIPTION
## Description

Teaclave compliains at runtime: `error while loading shared libraries: libsgx_uae_service.so: cannot open shared object file: No such file or directory` if `uae` is not installed.

Fixes # (issue)

## Type of change (select or add applied and delete the others)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How has this been tested?

## Checklist

- [ ] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the tests pass (see CI results).
- [ ] Make sure your code lints/format.
