### PR TITLE
Doc: C code can also be compiled using Zig

### DIFF
--- a/docs/executing-wasm.md
+++ b/docs/executing-wasm.md
@@ -49,6 +49,13 @@ You can also use `clang` provided by
 payload written in
 C](https://github.com/apache/incubator-teaclave/tree/master/examples/python/wasm_c_millionaire_problem_payload).
 
+Alternatively, C and C++ code can be compiled with [zig](https://ziglang.org):
+
+```sh
+zig cc  -Os --target=wasm32-freestanding -shared -o example.wasm example.c
+zig c++ -Os --target=wasm32-freestanding -shared -o example.wasm example.cpp
+```
+
 ## From Rust
 
 First of all, your cargo should support `wasm32` target and `wasm-gc` is


### PR DESCRIPTION
## Description

No need for another full LLVM installation if Zig is already installed.

Fixes # (issue)

## Type of change (select or add applied and delete the others)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How has this been tested?

By compiling the example code using `zig` instead of installing `wasi-sdk`.

## Checklist

- [X] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the tests pass (see CI results).
- [ ] Make sure your code lints/format.
