### PR TITLE
Fix container name of teaclave-file-service missing

### DIFF
--- a/docker/docker-compose-ubuntu-1804-intel-sgx.yml
+++ b/docker/docker-compose-ubuntu-1804-intel-sgx.yml
@@ -219,6 +219,7 @@ services:
 
   teaclave-file-service:
     image: python:3
+    container_name: teaclave-file-service
     volumes:
       - ../tests:/teaclave-file-service
     working_dir: /teaclave-file-service


### PR DESCRIPTION
## Description
This patch simply adds the missing container name of teaclave-file-service in DCAP docker compose file.

Fixes #557 

## Type of change (select or add applied and delete the others)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## Checklist

- [X] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the tests pass (see CI results).
- [ ] Make sure your code lints/format.
