### PR TITLE
Pin openssl to version 1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
           submodules: 'true'
       - name: Install dependencies
         run: |
-          brew install cmake openssl
+          brew install cmake openssl@1.1
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           export PATH=~/.cargo/bin:$PATH
           rustup default nightly-2020-04-07 && rustup target add aarch64-apple-ios x86_64-apple-ios
       - name: Building Teaclave Client SDK
         run: |
-          export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig:/usr/local/opt/libssh2/lib/pkgconfig/"
+          export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig:/usr/local/opt/libssh2/lib/pkgconfig/"
           export PATH=~/.cargo/bin:$PATH
           cargo +stable install cargo-lipo
           cargo build --manifest-path sdk/rust/Cargo.toml


### PR DESCRIPTION
## Description

Pining openssl to version 1.1 in CI for macos.

## Type of change (select or add applied and delete the others)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How has this been tested?

Tested by the GitHub Action CI.

## Checklist

- [x] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the tests pass (see CI results).
- [ ] Make sure your code lints/format.
