### PR TITLE
Use ./run-teaclave-services.sh -m sim in simulation mode

### DIFF
--- a/docs/my-first-function.md
+++ b/docs/my-first-function.md
@@ -118,7 +118,7 @@ $ export AS_URL="https://api.trustedservices.intel.com:443"    # IAS URL
 Launch all services with `docker-compose`:
 
 ```
-$ (cd docker && ./run-teaclave-services.sh)
+$ (cd docker && ./run-teaclave-services.sh -m sim)
 Starting teaclave-authentication-service ... done
 Starting teaclave-access-control-service ... done
 Starting teaclave-scheduler-service      ... done


### PR DESCRIPTION
## Description

Fix instruction to use `./run-teaclave-services.sh -m sim` in simulation mode

Fixes #562

## Type of change (select or add applied and delete the others)

- [x] Bug fix (non-breaking change which fixes an issue)

