### PR TITLE
[WAMR] check init return values

### DIFF
--- a/executor/src/wamr.rs
+++ b/executor/src/wamr.rs
@@ -116,7 +116,7 @@ impl TeaclaveExecutor for WAMicroRuntime {
         set_thread_context(Context::new(runtime))?;
 
         let ret = unsafe { wasm_runtime_init() };
-        assert!((ret as bool) != false);
+        assert!(ret != false);
 
         // export native function
         let export_symbols: [NativeSymbol; 5] = [

--- a/executor/src/wamr.rs
+++ b/executor/src/wamr.rs
@@ -115,10 +115,10 @@ impl TeaclaveExecutor for WAMicroRuntime {
 
         set_thread_context(Context::new(runtime))?;
 
-        unsafe { wasm_runtime_init() };
+        let ret = unsafe { wasm_runtime_init() };
+        assert!((ret as bool) != false);
 
         // export native function
-
         let export_symbols: [NativeSymbol; 5] = [
             NativeSymbol {
                 symbol: b"teaclave_open_input\0".as_ptr() as _,


### PR DESCRIPTION
## Description

Function `wasm_runtime_init ` may fail. This PR validates the return value.