### PR TITLE
Optimize memory footprint of serde in RPC

### DIFF
--- a/examples/python/wasm_rust_psi_payload/Cargo.lock
+++ b/examples/python/wasm_rust_psi_payload/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "teaclave_context"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "wasm_rust_psi_payload"

--- a/rpc/src/request.rs
+++ b/rpc/src/request.rs
@@ -24,7 +24,6 @@ pub struct Request<T> {
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(default)]
     pub metadata: HashMap<String, String>,
-    #[serde(flatten)]
     pub message: T,
 }
 

--- a/services/proto/proto_gen/templates/proto.j2
+++ b/services/proto/proto_gen/templates/proto.j2
@@ -18,7 +18,7 @@ under the License.
 #}
 
 #[derive(Clone, serde::Serialize, serde::Deserialize, Debug)]
-#[serde(tag = "request", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum {{ service.proto_name }}Request {
     {%- for m in service.methods %}
     {{ m.proto_name }}({{ m.input_type }}),

--- a/tests/scripts/functional_tests.py
+++ b/tests/scripts/functional_tests.py
@@ -140,9 +140,12 @@ class TestAuthenticationService(unittest.TestCase):
         user_password = "invalid_password"
 
         message = {
-            "request": "user_login",
-            "id": user_id,
-            "password": user_password
+            "message": {
+                "user_login": {
+                    "id": user_id,
+                    "password": user_password
+                }
+            }
         }
         write_message(self.socket, message)
 

--- a/types/src/staged_function.rs
+++ b/types/src/staged_function.rs
@@ -28,7 +28,6 @@ type ArgumentValue = serde_json::Value;
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct FunctionArguments {
-    #[serde(flatten)]
     inner: serde_json::Map<String, ArgumentValue>,
 }
 


### PR DESCRIPTION
## Description

This PR optimize memory footprint of RPC (i.e., memory used by serde).

Serde uses up more than 10x memory to deserialize a json message when using `#[serde(flatten)]` and `#[serde(tag = "request"]`.

In our case, we cannot handle more than 2M message because serde will allocation more than 100M bytes memory. The root cause is still unknown. With this PR, we can safely handle large requests in our services.

Note that this PR does not fix the Swift SDK accordingly. I'll fix it in later PRs.

## Type of change (select or add applied and delete the others)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
CI tests.

## Checklist

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
