### PR TITLE
Add the -b argument to rebuild services

### DIFF
--- a/docker/run-teaclave-services.sh
+++ b/docker/run-teaclave-services.sh
@@ -122,17 +122,18 @@ function aesm_detect() {
 }
 
 function usage {
-    echo "Usage: $(basename $0) [-hdm:]" 2>&1
+    echo "Usage: $(basename $0) [-hdbm:]" 2>&1
     echo '   -h           shows usage'
     echo '   -m           run mode (default: sgx)'
     echo '   -d           detached mode'
+    echo '   -b           build or rebuild services'
     echo 'Available run modes: sim, sgx'
     exit 1
 }
 
 RUN_MODE="sgx"
 DETACH_ARG=""
-optstring="hdm:"
+optstring="hdbm:"
 while getopts ${optstring} arg; do
     case ${arg} in
         h)
@@ -141,6 +142,9 @@ while getopts ${optstring} arg; do
             ;;
         d)
             DETACH_ARG="-d"
+            ;;
+        b)
+            BUILD_ARG="--build"
             ;;
         m)
             RUN_MODE=$OPTARG
@@ -215,5 +219,5 @@ else
     DC_ARGS="-f $DOCKER_COMPOSE_FILE"
 fi
 
-echo COMMAND: docker-compose ${DC_ARGS} up ${DETACH_ARG}
-docker-compose ${DC_ARGS} up ${DETACH_ARG}
+echo COMMAND: docker-compose ${DC_ARGS} up ${DETACH_ARG} ${BUILD_ARG}
+docker-compose ${DC_ARGS} up ${DETACH_ARG} ${BUILD_ARG}


### PR DESCRIPTION
## Description

Add the `-b` option to `docker/run-teaclave-services.sh` so that user can choose to rebuild all services, i.e., using `--build` argument to `docker-compose`.

## Type of change (select or add applied and delete the others)

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Local testing.

## Checklist

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
