### PR TITLE
[Fix] leveldb lru bug, using disk db for unit test.

### DIFF
--- a/common/rusty_leveldb_sgx/src/cache.rs
+++ b/common/rusty_leveldb_sgx/src/cache.rs
@@ -18,6 +18,49 @@ struct LRUList<T> {
     count: usize,
 }
 
+use std::fmt;
+impl<T> fmt::Display for LRUNode<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.next.is_some() {
+            let node = self.next.as_ref().unwrap();
+            writeln!(
+                f,
+                "(self: {:?}, next: {:?}, pre: {:?}, data:{})",
+                self as *const _,
+                (*node).as_ref() as *const _,
+                self.prev,
+                self.data.is_some()
+            )
+        } else {
+            writeln!(
+                f,
+                "(self: {:?}, next: {}, pre: {:?}, data:{})",
+                self as *const _,
+                "None",
+                self.prev,
+                self.data.is_some()
+            )
+        }
+    }
+}
+
+impl<T> fmt::Display for LRUList<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let _ = write!(
+            f,
+            "\n {:?}, count: {}, head: {}",
+            self as *const _, self.count, self.head
+        )?;
+        let mut opt_node = &self.head.next;
+        while opt_node.is_some() {
+            let node = opt_node.as_ref().unwrap();
+            let _ = write!(f, "\t {}", node)?;
+            opt_node = &node.next
+        }
+        writeln!(f,)
+    }
+}
+
 /// This is likely unstable; more investigation is needed into correct behavior!
 impl<T> LRUList<T> {
     fn new() -> LRUList<T> {
@@ -93,7 +136,7 @@ impl<T> LRUList<T> {
         unsafe {
             // If has next
             if let Some(ref mut nextp) = (*node_handle).next {
-                swap(&mut (**nextp).prev, &mut (*node_handle).prev);
+                (**nextp).prev = (*node_handle).prev;
             }
             // If has prev
             if let Some(ref mut prevp) = (*node_handle).prev {

--- a/services/storage/enclave/src/service.rs
+++ b/services/storage/enclave/src/service.rs
@@ -233,8 +233,12 @@ pub mod tests {
 
     fn get_mock_service() -> TeaclaveStorageService {
         let (_sender, receiver) = channel();
-        let opt = rusty_leveldb::in_memory();
-        let mut database = DB::open("mock_db", opt).unwrap();
+        let key = [
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x0f, 0x0e, 0x0d, 0x0c, 0x0b, 0x0a,
+            0x09, 0x08,
+        ];
+        let opt = rusty_leveldb::Options::new_disk_db_with(key);
+        let mut database = DB::open("mock_db_unit_test", opt).unwrap();
         database.put(b"test_get_key", b"test_get_value").unwrap();
         database
             .put(b"test_delete_key", b"test_delete_value")


### PR DESCRIPTION
## Description

In persistent mode, a LevelDB LRU assertion failure is triggered by our unit test case. This PR fix the issue in LRU::remove opertion. 

## Type of change (select or add applied and delete the others)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How has this been tested?

## Checklist

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
