### PR TITLE
Fix target depends to avoid issues in parallel make

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ add_custom_command(
   COMMAND
     wget -qN https://mesapy.org/release/${MESAPY_VERSION}-mesapy-sgx.tar.gz &&
     tar xzf ${MESAPY_VERSION}-mesapy-sgx.tar.gz
+  DEPENDS prep
   WORKING_DIRECTORY ${TEACLAVE_OUT_DIR})
 else()
   add_custom_command(
@@ -208,6 +209,7 @@ else()
         sgx/sgx_ulibc/libsgx_ulibc.a
         sgx/examples/exec/Enclave/src/ffi.o
         ${TEACLAVE_OUT_DIR}
+    DEPENDS prep
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/third_party/mesapy)
 endif()
 


### PR DESCRIPTION
## Description

In a clean clone, you cannot build with `make -j4` because of some target dependency issue. This PR fixes target depends to avoid issues in parallel make.

## Type of change (select or add applied and delete the others)

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
CI tests.

## Checklist

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
