### PR TITLE
Fix python sdk

### DIFF
--- a/sdk/python/teaclave.py
+++ b/sdk/python/teaclave.py
@@ -459,7 +459,7 @@ class AuthenticationService(TeaclaveService):
         _write_message(self.channel, request)
         response = _read_message(self.channel)
         if response["result"] == "ok":
-            return response["content"]["token"]
+            return response["content"]["password"]
         else:
             reason = "unknown"
             if "request_error" in response:


### PR DESCRIPTION
## Description

`ResetUserPasswordResponse`  is defined as
```Protobuf
message ResetUserPasswordResponse {
  string password = 1;
}
```
https://github.com/apache/incubator-teaclave/blob/55e658d96b92389cb8bd203640432c9493711dd3/services/proto/src/proto/teaclave_authentication_service.proto#L81

Therefore, the response is `password`.

## Type of change (select or add applied and delete the others)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How has this been tested?

## Checklist

- [ ] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [ ] Make sure your code lints/format.
