### PR TITLE
fix: code coverage report generation

### DIFF
--- a/cmake/scripts/gen_cov.sh
+++ b/cmake/scripts/gen_cov.sh
@@ -49,7 +49,7 @@ cd ${TEACLAVE_OUT_DIR} && ${LCOV} ${LCOVOPT} $(for tag in \
     `find ${TEACLAVE_PROJECT_ROOT} -name sgx_cov*.gcda | cut -d'.' -f2`; \
     do echo "--add modules_$tag.info"; done) \
     --add modules.info -o merged.info
-cd ${TEACLAVE_OUT_DIR} && python ${LCOV_REALPATH} merged.info > merged_realpath.info
+cd ${TEACLAVE_OUT_DIR} && python3 ${LCOV_REALPATH} merged.info > merged_realpath.info
 ${LCOV} ${LCOVOPT} --extract ${TEACLAVE_OUT_DIR}/merged_realpath.info \
     `find ${TEACLAVE_PROJECT_ROOT} -path ${TEACLAVE_PROJECT_ROOT}/third_party -prune -o \
     -path ${TEACLAVE_PROJECT_ROOT}/build -prune -o \

--- a/docker/build.ubuntu-1804.sgx-2.14.Dockerfile
+++ b/docker/build.ubuntu-1804.sgx-2.14.Dockerfile
@@ -130,6 +130,13 @@ RUN git clone https://github.com/apache/tvm /tvm                && \
     cmake -DUSE_LLVM=ON ..                                      && \
     make -j$(nproc)
 
+# Install llvm-cov version 11 from llvm-11
+RUN wget https://apt.llvm.org/llvm.sh                           && \
+    chmod +x llvm.sh                                            && \
+    ./llvm.sh 11                                                && \
+    update-alternatives --install /usr/bin/llvm-cov llvm-cov-11 /usr/bin/llvm-cov-11 11 && \
+    rm ./llvm.sh
+
 # clean up apt caches
 
 RUN apt-get clean && \

--- a/docker/build.ubuntu-1804.sgx-dcap-1.11.Dockerfile
+++ b/docker/build.ubuntu-1804.sgx-dcap-1.11.Dockerfile
@@ -138,6 +138,13 @@ RUN git clone https://github.com/apache/tvm /tvm                && \
     cmake -DUSE_LLVM=ON ..                                      && \
     make -j$(nproc)
 
+# Install llvm-cov version 11 from llvm-11
+RUN wget https://apt.llvm.org/llvm.sh                           && \
+    chmod +x llvm.sh                                            && \
+    ./llvm.sh 11                                                && \
+    update-alternatives --install /usr/bin/llvm-cov llvm-cov-11 /usr/bin/llvm-cov-11 11 && \
+    rm ./llvm.sh
+
 # clean up apt caches
 
 RUN apt-get clean && \

--- a/docker/build.ubuntu-2004.sgx-2.15.1.Dockerfile
+++ b/docker/build.ubuntu-2004.sgx-2.15.1.Dockerfile
@@ -130,6 +130,13 @@ RUN git clone https://github.com/apache/tvm /tvm                && \
     cmake -DUSE_LLVM=ON ..                                      && \
     make -j$(nproc)
 
+# Install llvm-cov version 11 from llvm-11
+RUN wget https://apt.llvm.org/llvm.sh                           && \
+    chmod +x llvm.sh                                            && \
+    ./llvm.sh 11                                                && \
+    update-alternatives --install /usr/bin/llvm-cov llvm-cov-11 /usr/bin/llvm-cov-11 11 && \
+    rm ./llvm.sh
+
 # clean up apt caches
 
 RUN apt-get clean && \

--- a/docker/build.ubuntu-2004.sgx-dcap-1.12.1.Dockerfile
+++ b/docker/build.ubuntu-2004.sgx-dcap-1.12.1.Dockerfile
@@ -138,6 +138,13 @@ RUN git clone https://github.com/apache/tvm /tvm                && \
     cmake -DUSE_LLVM=ON ..                                      && \
     make -j$(nproc)
 
+# Install llvm-cov version 11 from llvm-11
+RUN wget https://apt.llvm.org/llvm.sh                           && \
+    chmod +x llvm.sh                                            && \
+    ./llvm.sh 11                                                && \
+    update-alternatives --install /usr/bin/llvm-cov llvm-cov-11 /usr/bin/llvm-cov-11 11 && \
+    rm ./llvm.sh
+
 # clean up apt caches
 
 RUN apt-get clean && \

--- a/examples/python/wasm_tvm_mnist_payload/Makefile
+++ b/examples/python/wasm_tvm_mnist_payload/Makefile
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-TVM_HOME ?= /tvm
+# export TVM_HOME to prebuilt tvm-sys, don't change
+export TVM_HOME = /tvm
 export PYTHONPATH = $(shell printenv PYTHONPATH):${TVM_HOME}/python
 
 all:


### PR DESCRIPTION
## Description

Code coverage report generation has been stopped for a while due to toolchain upgrade. This PR fixes the report generation command `cmake -DCOV=ON` and `make cov`

Please release a set of build image after the merge.

Fixes # (issue)

## Type of change (select or add applied and delete the others)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [x] Code cleanup or just sync with upstream third-party crates

## How has this been tested?

Code coverage report has been generated successfully at https://gist.github.com/dingelish/186ecb02002bb273a47e0cbfd1196483

## Checklist

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
