### PR TITLE
fix link scripts

### DIFF
--- a/cmake/scripts/sgx_link_sign.sh
+++ b/cmake/scripts/sgx_link_sign.sh
@@ -44,10 +44,25 @@ if [ ! "$LIBENCLAVE_PATH" -nt "$SIGNED_PATH" ] \
     exit 0
 fi
 
-TEACLAVE_LINK_FLAGS="-L${TEACLAVE_OUT_DIR} -lpycomponent ffi.o -lpypy-c -lsgx_tlibc_ext -lffi"
-if [ "$TEACLAVE_EXECUTOR_WAMR" == "ON" ]; then
-    TEACLAVE_LINK_FLAGS+=" -lvmlib"
-fi
+TEACLAVE_LINK_FLAGS="-L${TEACLAVE_OUT_DIR}"
+
+case $CUR_PKG_NAME in
+
+  teaclave_access_control_service_enclave | teaclave_functional_tests_enclave )
+    TEACLAVE_LINK_FLAGS+=" -lpycomponent ffi.o -lpypy-c -lsgx_tlibc_ext -lffi"
+    ;;
+
+  teaclave_execution_service_enclave | teaclave_unit_tests_enclave |  teaclave_integration_tests_enclave)
+    TEACLAVE_LINK_FLAGS+=" -lpycomponent ffi.o -lpypy-c -lsgx_tlibc_ext -lffi"
+    if [ "$TEACLAVE_EXECUTOR_WAMR" == "ON" ]; then
+        TEACLAVE_LINK_FLAGS+=" -lvmlib"
+    fi
+    ;;
+
+  *)
+    ;;
+esac
+
 
 # Enable the security flags
 ENCLAVE_SECURITY_LINK_FLAGS="-Wl,-z,relro,-z,now,-z,noexecstack"


### PR DESCRIPTION
## Description

As discussed in #581, every service links `Mesapy` and `WAMR` into the `enclave.so`. While most linkers avoid linking unneeded static objects, it is not true for some libraries (e.g., sgx_trts).

`-Wl,-whole-archive  library-include-runtime.a -Wl,-no-whole-archive`

Fixes #581

## Type of change (select or add applied and delete the others)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How has this been tested?

## Checklist

- [ ] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the tests pass (see CI results).
- [ ] Make sure your code lints/format.
