### PR TITLE
Ignore rustflags set by the build system when compiling wasm payload

### DIFF
--- a/examples/python/wasm_rust_psi_payload/Makefile
+++ b/examples/python/wasm_rust_psi_payload/Makefile
@@ -16,7 +16,7 @@
 # under the License.
 
 all:
-	@cargo build --target wasm32-unknown-unknown --release
+	@RUSTFLAGS='' cargo build --target wasm32-unknown-unknown --release
 	@wasm-gc target/wasm32-unknown-unknown/release/wasm_rust_psi_payload.wasm
 
 clean:


### PR DESCRIPTION
## Description

Ignore rustflags set by the build system when compiling wasm payload.

## Type of change (select or add applied and delete the others)

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

https://ci.mesalock-linux.org/mssun/incubator-teaclave/139

## Checklist

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
