### PR TITLE
fix(docker): fix  detect device file with symlink

### DIFF
--- a/docker/run-teaclave-services.sh
+++ b/docker/run-teaclave-services.sh
@@ -30,14 +30,14 @@ function sgx_dev_detect() {
 
     local ENCL_DEV=/dev/sgx/enclave
     local ENCL_DEV_EXIST=false
-    if [ -L "$ENCL_DEV" ] && [ -c $(readlink $ENCL_DEV) ]; then
+    if [ -L "$ENCL_DEV" ] && [ -c $(realpath $ENCL_DEV) ]; then
         echo "$ENCL_DEV device detected."
         ENCL_DEV_EXIST=true
     fi
 
     local PROV_DEV=/dev/sgx/provision
     local PROV_DEV_EXIST=false
-    if [ -L "$PROV_DEV" ] && [ -c $(readlink $PROV_DEV) ]; then
+    if [ -L "$PROV_DEV" ] && [ -c $(realpath $PROV_DEV) ]; then
         echo "$PROV_DEV device detected."
         PROV_DEV_EXIST=true
     fi


### PR DESCRIPTION
## Description

Fix the `run-teaclave-services.sh` script. If files in `/dev/sgx` are symlinks, the current implementation will fail.

## Type of change (select or add applied and delete the others)

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Run scripts lcoally.

## Checklist

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
