### PR TITLE
Fix generate testing code coverage

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -169,7 +169,7 @@ node:
 ---
 
 x-isgx-2004-image: &isgx-2004-image
-  image: teaclave/teaclave-build-ubuntu-2004-sgx-2.15.1:0.1.2
+  image: teaclave/teaclave-build-ubuntu-2004-sgx-2.15.1:0.1.3
 
 kind: pipeline
 name: sgx-debug-ubuntu-2004
@@ -236,7 +236,7 @@ node:
 ---
 
 x-dcap-2004-image: &dcap-2004-image
-  image: teaclave/teaclave-build-ubuntu-2004-sgx-dcap-1.12.1:0.1.2
+  image: teaclave/teaclave-build-ubuntu-2004-sgx-dcap-1.12.1:0.1.3
 
 kind: pipeline
 name: sgx-dcap-debug-ubuntu-2004
@@ -324,7 +324,94 @@ node:
 ---
 
 x-dcap-2004-image: &dcap-2004-image
-  image: teaclave/teaclave-build-ubuntu-2004-sgx-dcap-1.12.1:0.1.2
+  image: teaclave/teaclave-build-ubuntu-2004-sgx-dcap-1.12.1:0.1.3
+
+kind: pipeline
+name: sgx-dcap-coverage-ubuntu-2004
+
+steps:
+- name: prepare
+  <<: *dcap-2004-image
+  commands:
+  - . /root/.cargo/env
+  - . /opt/sgxsdk/environment
+  - mkdir -p build
+  - cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTEST_MODE=ON -DDCAP=ON -DCOV=ON ..
+- name: check
+  <<: *dcap-2004-image
+  commands:
+  - . /root/.cargo/env
+  - . /opt/sgxsdk/environment
+  - cd build && make check
+- name: compile
+  <<: *dcap-2004-image
+  commands:
+  - . /root/.cargo/env
+  - . /opt/sgxsdk/environment
+  - sed -i 's/ias_root_ca_cert/dcap_root_ca_cert/' config/build.config.toml
+  - cd build && make VERBOSE=1 -j2
+- name: tvm example
+  image: teaclave/teaclave-build-ubuntu-1804-sgx-2.14:0.1.5
+  commands:
+  - . ~/.cargo/env
+  - cd examples/python/wasm_tvm_mnist_payload
+  - make
+- name: test
+  <<: *dcap-2004-image
+  environment:
+    AS_ALGO: sgx_ecdsa
+    AS_URL: https://localhost:8080
+    AS_KEY:
+      from_secret: V5_KEY
+    AS_SPID:
+      from_secret: V5_SPID
+  privileged: true
+  volumes:
+  - name: sgx
+    path: /dev/sgx
+  - name: sgx_enclave
+    path: /dev/sgx_enclave
+  - name: sgx_provision
+    path: /dev/sgx_provision
+  - name: aesmd
+    path: /var/run/aesmd/aesm.socket
+  - name: aesmd-conf
+    path: /etc/aesmd.conf
+  - name: qcnl
+    path: /etc/sgx_default_qcnl.conf
+  commands:
+  - echo "$(ip route | awk 'NR==1 {print $3}') pccs-server" >> /etc/hosts
+  - . /root/.cargo/env
+  - . /opt/sgxsdk/environment
+  - (cd release/dcap && ./teaclave_dcap_ref_as &)
+  - cd build && make run-tests && make cov
+
+volumes:
+- name: sgx
+  host:
+    path: /dev/sgx
+- name: sgx_enclave
+  host:
+    path: /dev/sgx_enclave
+- name: sgx_provision
+  host:
+    path: /dev/sgx_provision
+- name: aesmd
+  host:
+    path: /var/run/aesmd/aesm.socket
+- name: aesmd-conf
+  host:
+    path: /etc/aesmd.conf
+- name: qcnl
+  host:
+    path: /etc/sgx_default_qcnl.conf
+
+node:
+  instance: mesatee-sgx-dcap
+---
+
+x-dcap-2004-image: &dcap-2004-image
+  image: teaclave/teaclave-build-ubuntu-2004-sgx-dcap-1.12.1:0.1.3
 
 kind: pipeline
 name: sgx-dcap-release-ubuntu-2004
@@ -640,6 +727,7 @@ depends_on:
   - sgx-dcap-debug-ubuntu-1804
   - sgx-debug-ubuntu-2004
   - sgx-dcap-debug-ubuntu-2004
+  - sgx-dcap-coverage-ubuntu-2004
   - sgx-release-ubuntu-1804
   - sim-debug-ubuntu-1804
   - sim-release-ubuntu-1804

--- a/cmake/scripts/gen_cov.sh
+++ b/cmake/scripts/gen_cov.sh
@@ -30,6 +30,7 @@ GENHTML=genhtml
 
 cd ${TEACLAVE_PROJECT_ROOT}
 find . \( -name "*.gcda" -and \( ! -name "teaclave*" \
+     -and -name "teaclave_proto*" \
      -and ! -name "sgx_cov*" \
      -and ! -name "rusty_leveldb*" \
      -and ! -name "sgx_tprotected_fs*" \
@@ -39,11 +40,11 @@ cd ${TEACLAVE_PROJECT_ROOT} && \
     do mkdir -p ${TEACLAVE_OUT_DIR}/cov_$tag && \
     find ${TEACLAVE_TARGET_DIR} -name *$tag* -exec cp {} ${TEACLAVE_OUT_DIR}/cov_$tag/ \; ; \
     ${LCOV} ${LCOVOPT} --capture \
-    --directory ${TEACLAVE_OUT_DIR}/cov_$tag/ --base-directory . \
+    --directory ${TEACLAVE_OUT_DIR}/cov_$tag/ --base-directory .  --exclude "*target*" \
     -o ${TEACLAVE_OUT_DIR}/modules_$tag.info; done 2>/dev/null
 rm -rf ${TEACLAVE_OUT_DIR}/cov_*
 cd ${TEACLAVE_PROJECT_ROOT} && ${LCOV} ${LCOVOPT} --capture \
-    --directory . --base-directory . \
+    --directory . --base-directory . --exclude "*target*" \
     -o ${TEACLAVE_OUT_DIR}/modules.info 2>/dev/null
 cd ${TEACLAVE_OUT_DIR} && ${LCOV} ${LCOVOPT} $(for tag in \
     `find ${TEACLAVE_PROJECT_ROOT} -name sgx_cov*.gcda | cut -d'.' -f2`; \

--- a/cmake/scripts/llvm-gcov.sh
+++ b/cmake/scripts/llvm-gcov.sh
@@ -17,4 +17,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-llvm-cov gcov $*
+llvm-cov-11 gcov $*

--- a/cmake/scripts/test.sh
+++ b/cmake/scripts/test.sh
@@ -59,10 +59,10 @@ run_unit_tests() {
 }
 
 cleanup() {
-  # kill all background services
-  [[ -z "$(jobs -p -r)" ]] || kill -s SIGKILL $(jobs -p -r)
+  # gracefully terminate all background services with SIGTERM
+  [[ -z "$(jobs -p -r)" ]] || kill -s SIGTERM $(jobs -p -r)
   wait # wait for resource release
-  echo "All jobs killed."
+  echo "All jobs terminated."
 }
 
 wait_port() {

--- a/tests/integration/enclave/Enclave.config.xml
+++ b/tests/integration/enclave/Enclave.config.xml
@@ -21,8 +21,8 @@
 <EnclaveConfiguration>
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
-  <StackMaxSize>0x500000</StackMaxSize>
-  <HeapMaxSize>0x1000000</HeapMaxSize>
+  <StackMaxSize>0x900000</StackMaxSize>
+  <HeapMaxSize>0x2000000</HeapMaxSize>
   <TCSNum>22</TCSNum>
   <TCSPolicy>0</TCSPolicy>
   <DisableDebug>0</DisableDebug>


### PR DESCRIPTION
## Description

Fix inaccuracy of the coverage report. There three main reasons:
- use llvm-cov-11 instead of the default llvm (which may be llvm 10)
- increase heap and stack for the enclave of the integration test
- exclude some unnecessary when capture the coverage info

The new coverage result has been uploaded to coveralls: https://coveralls.io/builds/46626151

## Type of change (select or add applied and delete the others)

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
https://ci.mesalock-linux.org/mssun/incubator-teaclave/151

## Checklist

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
