### PR TITLE
Fix docker build issue caused by missing dependency of tomli

### DIFF
--- a/docker/build.ubuntu-1804-sgx-2.17.1.Dockerfile
+++ b/docker/build.ubuntu-1804-sgx-2.17.1.Dockerfile
@@ -101,7 +101,7 @@ RUN apt-get update && apt-get install -q -y \
     libjpeg-dev \
     zlib1g-dev
 
-RUN pip3 install pyopenssl==21.0.0 toml cryptography yapf requests Pillow
+RUN pip3 install pyopenssl==21.0.0 toml cryptography yapf requests Pillow tomli
 
 # install TVM dependencies
 RUN apt-get install -q -y \

--- a/docker/build.ubuntu-1804-sgx-dcap-1.14.Dockerfile
+++ b/docker/build.ubuntu-1804-sgx-dcap-1.14.Dockerfile
@@ -109,7 +109,7 @@ RUN apt-get update && apt-get install -q -y \
     libjpeg-dev \
     zlib1g-dev
 
-RUN pip3 install pyopenssl==21.0.0 toml cryptography yapf requests Pillow
+RUN pip3 install pyopenssl==21.0.0 toml cryptography yapf requests Pillow tomli
 
 # install TVM dependencies
 RUN apt-get install -q -y \


### PR DESCRIPTION
## Description

`docker build` for `build.ubuntu-1804-sgx-2.17.1.Dockerfile` and `build.ubuntu-1804-sgx-dcap-1.14.Dockerfile` fails due to missing dependency of `tomli`, a Python library.

```
$ docker build -t ubuntu-1804-sgx-2.17.1:latest . -f  docker/build.ubuntu-1804-sgx-dcap-1.14.Dockerfile
  Could not find a version that satisfies the requirement tomli>=2.0.1 (from yapf) (from versions: 0.2.0, 0.2.1, 0.2.2, 0.2.3, 0.2.4, 0.2.5, 0.2.6, 0.2.7, 0.2.8, 0.2.9, 0.2.10, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.1.0, 1.2.0, 1.2.1, 1.2.2, 1.2.3)
No matching distribution found for tomli>=2.0.1 (from yapf)
The command '/bin/sh -c pip3 install pyopenssl==21.0.0 toml cryptography yapf requests Pillow' returned a non-zero code: 1
```

I confirmed this issue doesn't happen with `build.ubuntu-2004-sgx-2.17.1.Dockerfile` or `build.ubuntu-2004-sgx-dcap-1.14.Dockerfile`.

## Type of change (select or add applied and delete the others)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How has this been tested?

## Checklist

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
