### PR TITLE
Fix deploy instruction for Azure to comply with SGX 2.17.

### DIFF
--- a/docs/azure-confidential-computing.md
+++ b/docs/azure-confidential-computing.md
@@ -52,10 +52,11 @@ Build Teaclave.
 $ git clone https://github.com/apache/incubator-teaclave.git
 $ cd incubator-teaclave
 $ docker run --rm -v $(pwd):/teaclave -w /teaclave \
-  -it teaclave/teaclave-build-ubuntu-1804-sgx-2.14:latest \
+  -it teaclave/teaclave-build-ubuntu-1804-sgx-2.17.1:0.1.0 \
    bash -c ". /root/.cargo/env && \
      . /opt/sgxsdk/environment && \
      mkdir -p build && cd build && \
+     git config --global --add safe.directory /teaclave && \
      cmake -DTEST_MODE=ON .. && \
      make"
 


### PR DESCRIPTION
## Description

The instruction for deployment on Azure doesn't work due to SGX 2.14 is used in the docker image `teaclave/teaclave-build-ubuntu-1804-sgx-2.14`.
Now that SGX 2.17 is required,  `teaclave/teaclave-build-ubuntu-1804-sgx-2.17.1` should be used.

## Type of change (select or add applied and delete the others)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How has this been tested?
Confirmed `docker run` passes with the new instruction.

## Checklist

- [x] Fork the repo and create your branch from `master`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the tests pass (see CI results).
- [x] Make sure your code lints/format.
