### PR TITLE
Fix advertised address

### DIFF
--- a/docker/runtime.config.toml
+++ b/docker/runtime.config.toml
@@ -26,12 +26,12 @@ authentication = { listen_address = "0.0.0.0:7776" }
 frontend       = { listen_address = "0.0.0.0:7777" }
 
 [internal_endpoints]
-authentication = { listen_address = "0.0.0.0:17776", advertised_address = "teaclave-authentication-service:17776" }
-management     = { listen_address = "0.0.0.0:17777", advertised_address = "teaclave-management-service:17777" }
-storage        = { listen_address = "0.0.0.0:17778", advertised_address = "teaclave-storage-service:17778" }
-access_control = { listen_address = "0.0.0.0:17779", advertised_address = "teaclave-access-control-service:17779" }
-execution      = { listen_address = "0.0.0.0:17770", advertised_address = "teaclave-execution-service:17770" }
-scheduler      = { listen_address = "0.0.0.0:17780", advertised_address = "teaclave-scheduler-service:17780" }
+authentication = { listen_address = "0.0.0.0:17776", advertised_address = "https://teaclave-authentication-service:17776" }
+management     = { listen_address = "0.0.0.0:17777", advertised_address = "https://teaclave-management-service:17777" }
+storage        = { listen_address = "0.0.0.0:17778", advertised_address = "https://teaclave-storage-service:17778" }
+access_control = { listen_address = "0.0.0.0:17779", advertised_address = "https://teaclave-access-control-service:17779" }
+execution      = { listen_address = "0.0.0.0:17770", advertised_address = "https://teaclave-execution-service:17770" }
+scheduler      = { listen_address = "0.0.0.0:17780", advertised_address = "https://teaclave-scheduler-service:17780" }
 
 [audit]
 enclave_info = { path = "enclave_info.toml" }


### PR DESCRIPTION
## Description

The runtime configuration for docker-compose has missing schemas in advertised addresses for services which will trigger an error if one tries to run Teaclave via docker-compose.

Fixes #706 

## Type of change (select or add applied and delete the others)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just sync with upstream third-party crates

## How has this been tested?

## Checklist

- [X] Fork the repo and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests.
- [ ] If you've changed APIs, update the documentation.
- [X] Ensure the tests pass (see CI results).
- [X] Make sure your code lints/format.
