### PR TITLE
Add AGENTS.md with security-model link for agent discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent guidance
+
+This file is read by automated agents (security scanners, code analyzers,
+AI assistants) operating on this repository. It points them at the
+human-authored references they should consult before producing output.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md` for the
+project's threat model, in-scope / out-of-scope declarations, and known
+non-findings before reporting issues.


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or discuss as needed.** Nothing here is a requirement; the maintainer is the decision-maker.

This adds an `AGENTS.md` so an automated scan agent can mechanically discover the project's security model via the conventional `AGENTS.md → SECURITY.md` chain. This repository already has a `SECURITY.md` (whose Security Model section points at `docs/security-model.md`, the map of scanning targets); this PR only adds the entry-point file that points at it. No existing content is changed.

Context: the ASF Security team is preparing this project for an automated agentic security scan we're piloting. Such scans refuse to run unless the model is mechanically discoverable by that path (refusing upfront beats wasting maintainer review cycles on a noise-heavy run against an unknown model). Discoverability is the one hard gate; the model content itself is untouched by this PR.

This mirrors apache/teaclave-trustzone-sdk#307, which made the same change for that repo.

Questions / pushback welcome — happy to adjust the wording or move the section if the project has a house style.